### PR TITLE
BTC instead of Sats on Stats For Nerds

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -730,7 +730,7 @@ class InfoView(ListAPIView):
             lifetime_volume = 0
 
         context["last_day_nonkyc_btc_premium"] = round(avg_premium, 2)
-        context["last_day_volume"] = total_volume *100000000
+        context["last_day_volume"] = total_volume
         context["lifetime_volume"] = lifetime_volume
         context["lnd_version"] = get_lnd_version()
         context["robosats_running_commit_hash"] = get_commit_robosats()

--- a/frontend/src/components/BottomBar.js
+++ b/frontend/src/components/BottomBar.js
@@ -152,7 +152,7 @@ class BottomBar extends Component {
                 <Divider/>
                 <ListItem>
                     <ListItemIcon><EqualizerIcon/></ListItemIcon>
-                    <ListItemText primary={pn(this.state.last_day_volume)+" Sats"} secondary={t("24h contracted volume")}/>
+                    <ListItemText primary={pn(this.state.last_day_volume)+" BTC"} secondary={t("24h contracted volume")}/>
                 </ListItem>
 
                 <Divider/>


### PR DESCRIPTION
In the "Stats For Nerds" we have now:

![image](https://user-images.githubusercontent.com/68381662/163728892-6039e872-e83b-4e26-9a27-f86390100e0c.png)

With this pretty good amount of daily volume, is better to have both amounts denominated in BTC:

![image](https://user-images.githubusercontent.com/68381662/163728944-eab1ab1e-9e9e-4a3c-be54-826739507c0b.png)

This PR tries to solve that. Can't test but only two minor changes.