### PR TITLE
Fix order book alignement in iOS

### DIFF
--- a/frontend/static/css/index.css
+++ b/frontend/static/css/index.css
@@ -136,3 +136,9 @@ input[type=number] {
 }
 
 .MuiButton-textInherit {color : '#111111';}
+
+@media (max-width: 929px) {
+  .MuiDataGrid-columnHeaders + div {
+    width: auto !important;
+  }
+}


### PR DESCRIPTION
Fix order book alignement in iOS, preventing it from appearing to the right (It would be necessary to check that this change doesn't affect Android devices)