### PR TITLE
Fix layout for small iOS devices and allow scroll

### DIFF
--- a/frontend/static/css/index.css
+++ b/frontend/static/css/index.css
@@ -142,7 +142,7 @@ input[type=number] {
     width: auto !important;
   }
 
-  .appCenter:has(>div.MuiGrid-root:first-child) {
+  .appCenter:has(>div.MuiGrid-root:first-child, >div.MuiBox-root:first-child) {
     overflow-y: scroll;
     margin-top: 12px;
     padding-bottom: 25px;

--- a/frontend/static/css/index.css
+++ b/frontend/static/css/index.css
@@ -141,4 +141,11 @@ input[type=number] {
   .MuiDataGrid-columnHeaders + div {
     width: auto !important;
   }
+
+  .appCenter:has(>div.MuiGrid-root:first-child) {
+    overflow-y: scroll;
+    margin-top: 12px;
+    padding-bottom: 25px;
+    height: 100%;
+  }
 }


### PR DESCRIPTION
Add css styles to fix the layout and allow scrolling in small iOS devices in order to solve 2 problems:
- top selectors are not totally visible
- bottom buttons are not visible (neither reachable because is not possible to scroll down) 

Added styles are only supported in Safari, so Android devices shouldn't be affected