### PR TITLE
Make robosats setup more easy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ setup.md
 docker-compose.yml
 .github
 .git
+node

--- a/.gitignore
+++ b/.gitignore
@@ -663,3 +663,4 @@ frontend/static/frontend/**
 docs/.jekyll-cache*
 docs/_site*
 commit_sha.txt
+node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       DEVELOPMENT: 1
     volumes:
       - .:/usr/src/robosats
-      - /mnt/development/lnd:/lnd
+      - ./node/lnd:/lnd
     network_mode: service:tor
     command: python3 -u manage.py runserver 0.0.0.0:8000
 
@@ -52,7 +52,7 @@ services:
     command: python3 manage.py clean_orders
     volumes:
       - .:/usr/src/robosats
-      - /mnt/development/lnd:/lnd
+      - ./node/lnd:/lnd
     network_mode: service:tor
 
   follow-invoices:
@@ -65,7 +65,7 @@ services:
     command: python3 manage.py follow_invoices
     volumes:
       - .:/usr/src/robosats
-      - /mnt/development/lnd:/lnd
+      - ./node/lnd:/lnd
     network_mode: service:tor
 
   telegram-watcher:
@@ -75,7 +75,7 @@ services:
     command: python3 manage.py telegram_watcher
     volumes:
       - .:/usr/src/robosats
-      - /mnt/development/lnd:/lnd
+      - ./node/lnd:/lnd
     network_mode: service:tor
 
   celery:
@@ -87,7 +87,7 @@ services:
       REDIS_URL: redis://localhost:6379
     volumes:
       - .:/usr/src/robosats
-      - /mnt/development/lnd:/lnd
+      - ./node/lnd:/lnd
     network_mode: service:tor
 
   i2p:
@@ -105,8 +105,8 @@ services:
       LOCAL_USER_ID: 1000
       LOCAL_GROUP_ID: 1000
     volumes:
-      - /mnt/development/tor/data:/var/lib/tor
-      - /mnt/development/tor/config:/etc/tor
+      - ./node/tor/data:/var/lib/tor
+      - ./node/tor/config:/etc/tor
     ports:
       - 8000:8000
 
@@ -119,10 +119,10 @@ services:
       - tor
       - bitcoind
     volumes:
-      - /mnt/development/tor/data:/var/lib/tor
-      - /mnt/development/tor/config:/etc/tor
-      - /mnt/development/lnd:/home/lnd/.lnd
-      - /mnt/development/lnd:/root/.lnd
+      - ./node/tor/data:/var/lib/tor
+      - ./node/tor/config:/etc/tor
+      - ./node/lnd:/home/lnd/.lnd
+      - ./node/lnd:/root/.lnd
     command: lnd
     environment:
       LOCAL_USER_ID: 1000
@@ -142,9 +142,9 @@ services:
       - tor
     network_mode: service:tor
     volumes:
-      - /mnt/development/tor/data:/var/lib/tor:ro
-      - /mnt/development/tor/config:/etc/tor:ro
-      - /mnt/development/bitcoin:/home/bitcoin/.bitcoin
+      - ./node/tor/data:/var/lib/tor:ro
+      - ./node/tor/config:/etc/tor:ro
+      - ./node/bitcoin:/home/bitcoin/.bitcoin
   
   postgres:
     image: postgres:14.2-alpine

--- a/setup.md
+++ b/setup.md
@@ -49,7 +49,7 @@ docker-compose build --no-cache
 # Install LND python dependencies into local repository
 docker run --mount type=bind,src=$(pwd),dst=/usr/src/robosats backend sh generate_grpc.sh
 docker-compose up -d
-docker exec -it django-dev python3 manage.py makemigrations
+docker exec -it django-dev python3 manage.py makemigrations api control chat
 docker exec -it django-dev python3 manage.py migrate
 docker exec -it django-dev python3 manage.py createsuperuser
 docker-compose restart


### PR DESCRIPTION
I just fixed the other problems mentioned in #208 
Setup should be much easier now
- Add apps `api`, `control` and `chat` to `makemigrations`
- Remove absolute path `/mnt/development` and use `./node` instead; you may want to create a symlink instead (`ln -s /mnt/development node`)