### PR TITLE
Client app for soverign nodes

### DIFF
--- a/.github/workflows/node-client-image.yml
+++ b/.github/workflows/node-client-image.yml
@@ -1,0 +1,68 @@
+name: RoboSats Client Node App Image CI/CD
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+    paths: ["frontend", "nodeapp"]
+  pull_request:
+    branches: [ "main" ]
+    paths: ["frontend", "nodeapp"]
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  push_to_registry:
+    name: 'Push Docker image to Docker Hub'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: 'Download main.js Artifact'
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: frontend-build.yml
+        workflow_conclusion: success
+        name: main-js
+        path: frontend/static/frontend/
+        
+    - name: 'Log in to Docker Hub'
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: 'Extract metadata (tags, labels) for Docker'
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: recksato/robosats-client
+        tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+
+    - name: 'Get Commit Hash'
+      id: commit
+      uses: pr-mpt/actions-commit-hash@v1
+
+    - name: 'Save Commit Long Hash to TXT File'
+      run: |
+        echo ${{ steps.commit.outputs.long }}>"commit_sha.txt"
+
+    - name: 'Build and push Docker image'
+      uses: docker/build-push-action@v3
+      with:
+        context: ./nodeapp
+        push: true
+        tags: |
+          recksato/robosats-client:${{ steps.commit.outputs.short }}
+          recksato/robosats-client:latest
+        labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/workflows/node-client-image.yml
+++ b/.github/workflows/node-client-image.yml
@@ -56,10 +56,17 @@ jobs:
       run: |
         echo ${{ steps.commit.outputs.long }}>"commit_sha.txt"
 
+    - name: 'Set up QEMU'
+      uses: docker/setup-qemu-action@v2
+    
+    - name: 'Set up Docker Buildx'
+      uses: docker/setup-buildx-action@v2
+    
     - name: 'Build and push Docker image'
       uses: docker/build-push-action@v3
       with:
         context: ./nodeapp
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: |
           recksato/robosats-client:${{ steps.commit.outputs.short }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,16 @@ services:
     volumes:
       - ./frontend:/usr/src/frontend
 
+  nodeapp: # Umbrel / Citadel app
+    build: ./nodeapp
+    container_name: nodeapp-dev
+    restart: always
+    environment:
+      TOR_PROXY_IP: 127.0.0.1
+      TOP_PROXY_PORT: 9050
+      ROBOSATS_ONION: robosats6tkf3eva7x2voqso3a5wcorsnw34jveyxfqi2fu7oyheasid.onion
+    network_mode: service:tor
+
   clean-orders:
     image: backend
     restart: always
@@ -108,7 +118,8 @@ services:
       - ./node/tor/data:/var/lib/tor
       - ./node/tor/config:/etc/tor
     ports:
-      - 8000:8000
+      - 8000:8000     # dev frontend build
+      - 12596:12596   # umbrel frontend
 
   lnd:
     build: ./docker/lnd

--- a/nodeapp/.dockerignore
+++ b/nodeapp/.dockerignore
@@ -1,0 +1,1 @@
+README.md

--- a/nodeapp/Dockerfile
+++ b/nodeapp/Dockerfile
@@ -5,8 +5,10 @@ WORKDIR /usr/src/robosats
 
 COPY . .
 
+RUN apt-get update
+RUN apt-get install -y socat
 RUN npm install http-server
 
 EXPOSE 12596
 
-CMD http-server . -p 12596 -P http://127.0.0.1:81 & nohup socat tcp4-LISTEN:81,reuseaddr,fork,keepalive,bind=127.0.0.1 SOCKS4A:${TOR_PROXY_IP:-127.0.0.1}:${ROBOSATS_ONION:-http://robosats6tkf3eva7x2voqso3a5wcorsnw34jveyxfqi2fu7oyheasid.onion}:80,socksport=${TOR_PROXY_PORT:-9050}
+CMD npm exec http-server -- . -p 12596 -P http://127.0.0.1:81 -i false -d false & nohup socat tcp4-LISTEN:81,reuseaddr,fork,keepalive,bind=127.0.0.1 SOCKS4A:${TOR_PROXY_IP:-127.0.0.1}:${ROBOSATS_ONION:-robosats6tkf3eva7x2voqso3a5wcorsnw34jveyxfqi2fu7oyheasid.onion}:80,socksport=${TOR_PROXY_PORT:-9050}

--- a/nodeapp/Dockerfile
+++ b/nodeapp/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:18-bullseye-slim
+
+RUN mkdir -p /usr/src/robosats
+WORKDIR /usr/src/robosats
+
+COPY . .
+
+RUN npm install http-server
+
+EXPOSE 12596
+
+CMD http-server . -p 12596 -P http://127.0.0.1:81 & nohup socat tcp4-LISTEN:81,reuseaddr,fork,keepalive,bind=127.0.0.1 SOCKS4A:${TOR_PROXY_IP:-127.0.0.1}:${ROBOSATS_ONION:-http://robosats6tkf3eva7x2voqso3a5wcorsnw34jveyxfqi2fu7oyheasid.onion}:80,socksport=${TOR_PROXY_PORT:-9050}

--- a/nodeapp/README.md
+++ b/nodeapp/README.md
@@ -1,0 +1,5 @@
+# RoboSats app for soverign nodes.
+
+RoboSats app for soverign nodes (e.g. Umbrel / Citadel / Start9 . This app serves the RoboSats frontend app directly from your own node and redirects all API requests to RoboSats P2P market coordinator through your node's TOR proxy.
+
+At the moment it has no default integration with your local lightning wallet (e.g. LND). Yet, this can easily be achieves by installing a WebLN compatible extension in your browser (e.g. getAlby).

--- a/nodeapp/README.md
+++ b/nodeapp/README.md
@@ -1,5 +1,7 @@
 # RoboSats app for soverign nodes.
 
-RoboSats app for soverign nodes (e.g. Umbrel / Citadel / Start9 . This app serves the RoboSats frontend app directly from your own node and redirects all API requests to RoboSats P2P market coordinator through your node's TOR proxy.
+RoboSats app for soverign nodes ( Umbrel, Citadel, Start9 ...). This app serves the RoboSats frontend app directly from your own node and redirects all API requests to RoboSats P2P market coordinator through your node's TOR proxy.
 
-At the moment it has no default integration with your local lightning wallet (e.g. LND). Yet, this can easily be achieves by installing a WebLN compatible extension in your browser (e.g. getAlby).
+At the moment it has no special integration with your local lightning wallet (e.g. LND). This can be achieved easily by installing a WebLN compatible extension in your browser (e.g. getAlby).
+
+The container launches two processes: 1) A `socat` that will expose RoboSats coordinator API over HTTP using the docker orchestration Tor socks proxy and 2) a `http-server` that will serve all static files (including the Javascript client app) directly from your own node (should reduce loading times by a lot). Every request that cannot be served by your node http-server will be forwarded to the RoboSats coordinator (that is: API calls and Robot avatar images).

--- a/nodeapp/static
+++ b/nodeapp/static
@@ -1,0 +1,1 @@
+../frontend/static


### PR DESCRIPTION
A simple app to run on your sovereign node to host your own RoboSats client. API calls to the P2P market coordinator are torified by your node TOR proxy. Ideal for inclusion on Umbrel, Citadel, Start9, etc.

Advantages over a full _over-the-internet_ RoboSats experience:
- Dramatically faster load times.
- Safer: you control what RoboSats client app you run.
- Access RoboSats safely from any browser / device. No need to use TOR if you are on your local network or using VPN: your node backend handles the torification needed for anonymization.
- Allows control over what P2P market coordinator you connect to.