### PR TITLE
Add QR Code to enable Telegram notifications

### DIFF
--- a/frontend/src/components/TradeBox.js
+++ b/frontend/src/components/TradeBox.js
@@ -367,6 +367,9 @@ class TradeBox extends Component {
           {t("Enable TG Notifications")}
         </DialogTitle>
         <DialogContent>
+          <div style={{textAlign:"center"}}>
+            <QRCode value={"tg://resolve?domain="+this.props.data.tg_bot_name+"&start="+this.props.data.tg_token} size={275}/>
+          </div> 
           <DialogContentText id="alert-dialog-description">
             {t("You will be taken to a conversation with RoboSats telegram bot. Simply open the chat and press Start. Note that by enabling telegram notifications you might lower your level of anonymity.")}
           </DialogContentText>


### PR DESCRIPTION
Add QR Code with `tg://` link to the "Enable Telegram Dialog".

This feature should allow users get into the chatbot on their phones easily when scanning the QR code from Tor Browser desktop. 