### PR TITLE
Fix error when query parameters not passed

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -822,8 +822,8 @@ class BookView(ListAPIView):
     queryset = Order.objects.filter(status=Order.Status.PUB)
 
     def get(self, request, format=None):
-        currency = request.GET.get("currency")
-        type = request.GET.get("type")
+        currency = request.GET.get("currency", 0)
+        type = request.GET.get("type", 2)
 
         queryset = Order.objects.filter(status=Order.Status.PUB)
 


### PR DESCRIPTION
if no parameters are passed to `/api/book`, then just return orders of ALL currency and of ANY type.

Currently, if no query parameters are passed, then the API returns 500 status code.