### PR TITLE
Book functional component

### DIFF
--- a/frontend/src/components/BookPage.js
+++ b/frontend/src/components/BookPage.js
@@ -34,21 +34,6 @@ class BookPage extends Component {
 
   componentDidMount = () => {
     this.getOrderDetails();
-
-    if (typeof window !== undefined) {
-      this.setState({ windowWidth: window.innerWidth, windowHeight: window.innerHeight });
-      window.addEventListener('resize', this.onResize);
-    }
-  };
-
-  componentWillUnmount = () => {
-    if (typeof window !== undefined) {
-      window.removeEventListener('resize', this.onResize);
-    }
-  };
-
-  onResize = () => {
-    this.setState({ windowWidth: window.innerWidth, windowHeight: window.innerHeight });
   };
 
   getOrderDetails() {
@@ -137,8 +122,8 @@ class BookPage extends Component {
           compact={true}
           setAppState={this.props.setAppState}
           limits={this.props.limits}
-          maxWidth={(this.state.windowWidth / this.props.theme.typography.fontSize) * 0.8} // EM units
-          maxHeight={(this.state.windowHeight / this.props.theme.typography.fontSize) * 0.8 - 11} // EM units
+          maxWidth={(this.props.windowWidth / this.props.theme.typography.fontSize) * 0.8} // EM units
+          maxHeight={(this.props.windowHeight / this.props.theme.typography.fontSize) * 0.8 - 11} // EM units
         />
       );
     } else {
@@ -148,8 +133,8 @@ class BookPage extends Component {
           orders={this.props.bookOrders}
           type={this.props.type}
           currency={this.props.currency}
-          maxWidth={(this.state.windowWidth / this.props.theme.typography.fontSize) * 0.97} // EM units
-          maxHeight={(this.state.windowHeight / this.props.theme.typography.fontSize) * 0.8 - 11} // EM units
+          maxWidth={(this.props.windowWidth / this.props.theme.typography.fontSize) * 0.97} // EM units
+          maxHeight={(this.props.windowHeight / this.props.theme.typography.fontSize) * 0.8 - 11} // EM units
         />
       );
     }

--- a/frontend/src/components/BookPage.js
+++ b/frontend/src/components/BookPage.js
@@ -33,6 +33,7 @@ import { apiClient } from '../services/api/index';
 
 // Icons
 import { BarChart, FormatListBulleted, Refresh } from '@mui/icons-material';
+import BookTable from './BookTable';
 
 class BookPage extends Component {
   constructor(props) {
@@ -145,153 +146,6 @@ class BookPage extends Component {
     };
   };
 
-  bookListTableDesktop = () => {
-    const { t } = this.props;
-    return (
-      <div style={{ height: 424, width: '100%' }}>
-        <DataGrid
-          localeText={this.dataGridLocaleText()}
-          rows={this.props.bookOrders.filter(
-            (order) =>
-              (order.type == this.props.type || this.props.type == null) &&
-              (order.currency == this.props.currency || this.props.currency == 0),
-          )}
-          loading={this.props.bookLoading}
-          columns={[
-            // { field: 'id', headerName: 'ID', width: 40 },
-            {
-              field: 'maker_nick',
-              headerName: t('Robot'),
-              width: 240,
-              renderCell: (params) => {
-                return (
-                  <ListItemButton style={{ cursor: 'pointer' }}>
-                    <ListItemAvatar>
-                      <RobotAvatar
-                        nickname={params.row.maker_nick}
-                        style={{ width: 45, height: 45 }}
-                        smooth={true}
-                        orderType={params.row.type}
-                        statusColor={this.statusBadgeColor(params.row.maker_status)}
-                        tooltip={t(params.row.maker_status)}
-                      />
-                    </ListItemAvatar>
-                    <ListItemText primary={params.row.maker_nick} />
-                  </ListItemButton>
-                );
-              },
-            },
-            {
-              field: 'type',
-              headerName: t('Is'),
-              width: 60,
-              renderCell: (params) => (params.row.type ? t('Seller') : t('Buyer')),
-            },
-            {
-              field: 'amount',
-              headerName: t('Amount'),
-              type: 'number',
-              width: 90,
-              renderCell: (params) => {
-                return (
-                  <div style={{ cursor: 'pointer' }}>
-                    {amountToString(
-                      params.row.amount,
-                      params.row.has_range,
-                      params.row.min_amount,
-                      params.row.max_amount,
-                    )}
-                  </div>
-                );
-              },
-            },
-            {
-              field: 'currency',
-              headerName: t('Currency'),
-              width: 100,
-              renderCell: (params) => {
-                const currencyCode = this.getCurrencyCode(params.row.currency);
-                return (
-                  <div
-                    style={{
-                      cursor: 'pointer',
-                      display: 'flex',
-                      alignItems: 'center',
-                      flexWrap: 'wrap',
-                    }}
-                  >
-                    {currencyCode + ' '}
-                    <FlagWithProps code={currencyCode} />
-                  </div>
-                );
-              },
-            },
-            {
-              field: 'payment_method',
-              headerName: t('Payment Method'),
-              width: 180,
-              renderCell: (params) => {
-                return (
-                  <div style={{ cursor: 'pointer' }}>
-                    <PaymentText
-                      othersText={t('Others')}
-                      verbose={true}
-                      size={24}
-                      text={params.row.payment_method}
-                    />
-                  </div>
-                );
-              },
-            },
-            {
-              field: 'price',
-              headerName: t('Price'),
-              type: 'number',
-              width: 140,
-              renderCell: (params) => {
-                const currencyCode = this.getCurrencyCode(params.row.currency);
-                return (
-                  <div style={{ cursor: 'pointer' }}>
-                    {pn(params.row.price) + ' ' + currencyCode + '/BTC'}
-                  </div>
-                );
-              },
-            },
-            {
-              field: 'premium',
-              headerName: t('Premium'),
-              type: 'number',
-              width: 100,
-              renderCell: (params) => {
-                return (
-                  <div style={{ cursor: 'pointer' }}>
-                    {parseFloat(parseFloat(params.row.premium).toFixed(4)) + '%'}
-                  </div>
-                );
-              },
-            },
-          ]}
-          components={{
-            NoRowsOverlay: () => (
-              <Stack height='100%' alignItems='center' justifyContent='center'>
-                <div style={{ height: '220px' }} />
-                {this.NoOrdersFound()}
-              </Stack>
-            ),
-            NoResultsOverlay: () => (
-              <Stack height='100%' alignItems='center' justifyContent='center'>
-                {t('Filter has no results')}
-              </Stack>
-            ),
-          }}
-          pageSize={this.props.bookLoading ? 0 : this.state.pageSize}
-          rowsPerPageOptions={[0, 6, 20, 50]}
-          onPageSizeChange={(newPageSize) => this.setState({ pageSize: newPageSize })}
-          onRowClick={(params) => this.handleRowClick(params.row.id)} // Whole row is clickable, but the mouse only looks clickly in some places.
-        />
-      </div>
-    );
-  };
 
   bookListTablePhone = () => {
     const { t } = this.props;
@@ -495,45 +349,28 @@ class BookPage extends Component {
       return this.NoOrdersFound();
     }
 
-    const components =
-      this.state.view == 'depth'
-        ? [
-            <DepthChart
-              bookLoading={this.props.bookLoading}
-              orders={this.props.bookOrders}
-              lastDayPremium={this.props.lastDayPremium}
-              currency={this.props.currency}
-              setAppState={this.props.setAppState}
-              limits={this.props.limits}
-            />,
-            <DepthChart
-              bookLoading={this.props.bookLoading}
-              orders={this.props.bookOrders}
-              lastDayPremium={this.props.lastDayPremium}
-              currency={this.props.currency}
-              compact={true}
-              setAppState={this.props.setAppState}
-              limits={this.props.limits}
-            />,
-          ]
-        : [this.bookListTableDesktop(), this.bookListTablePhone()];
-
-    return (
-      <>
-        {/* Desktop */}
-        <MediaQuery minWidth={930}>
-          <Paper elevation={0} style={{ width: 925, maxHeight: 510, overflow: 'auto' }}>
-            <div style={{ height: 424, width: '100%' }}>{components[0]}</div>
-          </Paper>
-        </MediaQuery>
-        {/* Smartphone */}
-        <MediaQuery maxWidth={929}>
-          <Paper elevation={0} style={{ width: 395, maxHeight: 460, overflow: 'auto' }}>
-            <div style={{ height: 424, width: '100%' }}>{components[1]}</div>
-          </Paper>
-        </MediaQuery>
-      </>
-    );
+    if (this.state.view === 'depth') {
+      return (
+        <DepthChart
+            bookLoading={this.props.bookLoading}
+            orders={this.props.bookOrders}
+            lastDayPremium={this.props.lastDayPremium}
+            currency={this.props.currency}
+            compact={true}
+            setAppState={this.props.setAppState}
+            limits={this.props.limits}
+          />
+      )
+    }else{
+        return(
+          <BookTable 
+            loading={this.props.bookLoading}
+            orders={this.props.bookOrders}
+            type={this.props.type}
+            currency={this.props.currency}
+          />
+        )
+      }
   };
 
   getTitle = () => {

--- a/frontend/src/components/BookPage.js
+++ b/frontend/src/components/BookPage.js
@@ -123,7 +123,6 @@ class BookPage extends Component {
   };
 
   mainView = () => {
-    console.log(this.state.windowWidth, this.state.windowHeight);
     if (this.props.bookNotFound) {
       return this.NoOrdersFound();
     }
@@ -147,10 +146,8 @@ class BookPage extends Component {
           orders={this.props.bookOrders}
           type={this.props.type}
           currency={this.props.currency}
-          maxWidth={(this.state.windowWidth * 0.8) / this.props.theme.typography.fontSize} // EM units
-          maxHeight={
-            (this.state.windowHeight * 0.9) / this.props.theme.typography.fontSize - 300 / 16
-          } // EM units
+          maxWidth={(this.state.windowWidth / this.props.theme.typography.fontSize) * 0.97} // EM units
+          maxHeight={(this.state.windowHeight / this.props.theme.typography.fontSize) * 0.8 - 11} // EM units
         />
       );
     }

--- a/frontend/src/components/BookPage.js
+++ b/frontend/src/components/BookPage.js
@@ -137,6 +137,8 @@ class BookPage extends Component {
           compact={true}
           setAppState={this.props.setAppState}
           limits={this.props.limits}
+          maxWidth={(this.state.windowWidth / this.props.theme.typography.fontSize) * 0.8} // EM units
+          maxHeight={(this.state.windowHeight / this.props.theme.typography.fontSize) * 0.8 - 11} // EM units
         />
       );
     } else {

--- a/frontend/src/components/BookTable.tsx
+++ b/frontend/src/components/BookTable.tsx
@@ -1,0 +1,879 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHistory } from "react-router-dom";
+import {
+  Tooltip,
+  Paper,
+  Stack,
+  ListItemButton,
+  ListItemText,
+  ListItemAvatar,
+} from '@mui/material';
+import { DataGrid } from '@mui/x-data-grid';
+import currencyDict from '../../static/assets/currencies.json';
+import { Order } from '../models/Order.model';
+
+import FlagWithProps from './FlagWithProps';
+import { pn, amountToString } from '../utils/prettyNumbers';
+import PaymentText from './PaymentText';
+import RobotAvatar from './Robots/RobotAvatar';
+
+function statusBadgeColor(status) {
+  if (status === 'Active') {
+    return 'success';
+  }
+  if (status === 'Seen recently') {
+    return 'warning';
+  }
+  if (status === 'Inactive') {
+    return 'error';
+  }
+}
+
+function getCurrencyCode(val) {
+  const { t } = useTranslation();
+  if (val) {
+    return val == 0 ? t('ANY_currency') : currencyDict[val.toString()];
+  } else {
+    return t('ANY_currency');
+  }
+}
+
+function localizeDataGrid(){
+  const { t } = useTranslation();
+  return {
+    MuiTablePagination: { labelRowsPerPage: t('Orders per page:') },
+    noRowsLabel: t('No rows'),
+    noResultsOverlayLabel: t('No results found.'),
+    errorOverlayDefaultLabel: t('An error occurred.'),
+    toolbarColumns: t('Columns'),
+    toolbarColumnsLabel: t('Select columns'),
+    columnsPanelTextFieldLabel: t('Find column'),
+    columnsPanelTextFieldPlaceholder: t('Column title'),
+    columnsPanelDragIconLabel: t('Reorder column'),
+    columnsPanelShowAllButton: t('Show all'),
+    columnsPanelHideAllButton: t('Hide all'),
+    filterPanelAddFilter: t('Add filter'),
+    filterPanelDeleteIconLabel: t('Delete'),
+    filterPanelLinkOperator: t('Logic operator'),
+    filterPanelOperators: t('Operator'),
+    filterPanelOperatorAnd: t('And'),
+    filterPanelOperatorOr: t('Or'),
+    filterPanelColumns: t('Columns'),
+    filterPanelInputLabel: t('Value'),
+    filterPanelInputPlaceholder: t('Filter value'),
+    filterOperatorContains: t('contains'),
+    filterOperatorEquals: t('equals'),
+    filterOperatorStartsWith: t('starts with'),
+    filterOperatorEndsWith: t('ends with'),
+    filterOperatorIs: t('is'),
+    filterOperatorNot: t('is not'),
+    filterOperatorAfter: t('is after'),
+    filterOperatorOnOrAfter: t('is on or after'),
+    filterOperatorBefore: t('is before'),
+    filterOperatorOnOrBefore: t('is on or before'),
+    filterOperatorIsEmpty: t('is empty'),
+    filterOperatorIsNotEmpty: t('is not empty'),
+    filterOperatorIsAnyOf: t('is any of'),
+    filterValueAny: t('any'),
+    filterValueTrue: t('true'),
+    filterValueFalse: t('false'),
+    columnMenuLabel: t('Menu'),
+    columnMenuShowColumns: t('Show columns'),
+    columnMenuFilter: t('Filter'),
+    columnMenuHideColumn: t('Hide'),
+    columnMenuUnsort: t('Unsort'),
+    columnMenuSortAsc: t('Sort by ASC'),
+    columnMenuSortDesc: t('Sort by DESC'),
+    columnHeaderFiltersLabel: t('Show filters'),
+    columnHeaderSortIconLabel: t('Sort'),
+    booleanCellTrueLabel: t('yes'),
+    booleanCellFalseLabel: t('no'),
+  };
+};
+
+interface Props {
+  loading: boolean;
+  orders: Order[];
+  type: Number;
+  currency: Number;
+}
+
+const BookTable = ({
+  loading,
+  orders,
+  type,
+  currency,
+}: Props): JSX.Element => {
+  const { t } = useTranslation();
+  const { history } = useHistory(); 
+  var pageSize = 6;
+
+  const handleRowClick = (e) => {
+    history.push('/order/' + e);
+  };
+
+  // Use effect gets height and width and then adjusts the size of everything below!
+
+  return (
+    <Paper elevation={0} style={{ width: 925, maxHeight: 510, overflow: 'auto' }}>
+      <div style={{ height: 424, width: '100%' }}>
+        <DataGrid
+          localeText={localizeDataGrid()}
+          rows={orders.filter(
+            (order) =>
+              (order.type == type || type == null) &&
+              (order.currency == currency || currency == 0),
+          )}
+          loading={loading}
+          columns={[
+            // { field: 'id', headerName: 'ID', width: 40 },
+            {
+              field: 'maker_nick',
+              headerName: t('Robot'),
+              width: 240,
+              renderCell: (params) => {
+                return (
+                  <ListItemButton style={{ cursor: 'pointer' }}>
+                    <ListItemAvatar>
+                      <RobotAvatar
+                        nickname={params.row.maker_nick}
+                        style={{ width: 45, height: 45 }}
+                        smooth={true}
+                        orderType={params.row.type}
+                        statusColor={statusBadgeColor(params.row.maker_status)}
+                        tooltip={t(params.row.maker_status)}
+                      />
+                    </ListItemAvatar>
+                    <ListItemText primary={params.row.maker_nick} />
+                  </ListItemButton>
+                );
+              },
+            },
+            {
+              field: 'type',
+              headerName: t('Is'),
+              width: 60,
+              renderCell: (params) => (params.row.type ? t('Seller') : t('Buyer')),
+            },
+            {
+              field: 'amount',
+              headerName: t('Amount'),
+              type: 'number',
+              width: 90,
+              renderCell: (params) => {
+                return (
+                  <div style={{ cursor: 'pointer' }}>
+                    {amountToString(
+                      params.row.amount,
+                      params.row.has_range,
+                      params.row.min_amount,
+                      params.row.max_amount,
+                    )}
+                  </div>
+                );
+              },
+            },
+            {
+              field: 'currency',
+              headerName: t('Currency'),
+              width: 100,
+              renderCell: (params) => {
+                const currencyCode = getCurrencyCode(params.row.currency);
+                return (
+                  <div
+                    style={{
+                      cursor: 'pointer',
+                      display: 'flex',
+                      alignItems: 'center',
+                      flexWrap: 'wrap',
+                    }}
+                  >
+                    {currencyCode + ' '}
+                    <FlagWithProps code={currencyCode} />
+                  </div>
+                );
+              },
+            },
+            {
+              field: 'payment_method',
+              headerName: t('Payment Method'),
+              width: 180,
+              renderCell: (params) => {
+                return (
+                  <div style={{ cursor: 'pointer' }}>
+                    <PaymentText
+                      othersText={t('Others')}
+                      verbose={true}
+                      size={24}
+                      text={params.row.payment_method}
+                    />
+                  </div>
+                );
+              },
+            },
+            {
+              field: 'price',
+              headerName: t('Price'),
+              type: 'number',
+              width: 140,
+              renderCell: (params) => {
+                const currencyCode = getCurrencyCode(params.row.currency);
+                return (
+                  <div style={{ cursor: 'pointer' }}>
+                    {pn(params.row.price) + ' ' + currencyCode + '/BTC'}
+                  </div>
+                );
+              },
+            },
+            {
+              field: 'premium',
+              headerName: t('Premium'),
+              type: 'number',
+              width: 100,
+              renderCell: (params) => {
+                return (
+                  <div style={{ cursor: 'pointer' }}>
+                    {parseFloat(parseFloat(params.row.premium).toFixed(4)) + '%'}
+                  </div>
+                );
+              },
+            },
+          ]}
+          components={{
+            NoRowsOverlay: () => (
+              <Stack height='100%' alignItems='center' justifyContent='center'>
+                <div style={{ height: '220px' }} />
+                {"this.NoOrdersFound()"}
+              </Stack>
+            ),
+            NoResultsOverlay: () => (
+              <Stack height='100%' alignItems='center' justifyContent='center'>
+                {t('Filter has no results')}
+              </Stack>
+            ),
+          }}
+          pageSize={loading ? 0 : pageSize}
+          rowsPerPageOptions={[0, 6, 20, 50]}
+          onPageSizeChange={(newPageSize) => { pageSize= newPageSize }}
+          onRowClick={(params) => handleRowClick(params.row.id)} // Whole row is clickable, but the mouse only looks clickly in some places.
+        />
+        </div>
+      </Paper>
+  );
+};
+
+export default BookTable;
+
+
+// class BookPage extends Component {
+//   constructor(props) {
+//     super(props);
+//     this.state = {
+//       pageSize: 6,
+//       view: 'list',
+//     };
+//   }
+
+//   componentDidMount() {
+//     this.getOrderDetails(2, 0);
+//   }
+
+//   getOrderDetails(type, currency) {
+//     this.props.setAppState({ bookLoading: true });
+//     apiClient.get('/api/book/').then((data) =>
+//       this.props.setAppState({
+//         bookNotFound: data.not_found,
+//         bookLoading: false,
+//         bookOrders: data,
+//       }),
+//     );
+//   }
+
+//   handleRowClick = (e) => {
+//     this.props.history.push('/order/' + e);
+//   };
+
+//   handleCurrencyChange = (e) => {
+//     const currency = e.target.value;
+//     this.props.setAppState({
+//       currency,
+//       bookCurrencyCode: this.getCurrencyCode(currency),
+//     });
+//   };
+
+//   getCurrencyCode(val) {
+//     const { t } = this.props;
+//     if (val) {
+//       return val == 0 ? t('ANY_currency') : currencyDict[val.toString()];
+//     } else {
+//       return t('ANY_currency');
+//     }
+//   }
+
+//   // Colors for the status badges
+//   statusBadgeColor(status) {
+//     if (status === 'Active') {
+//       return 'success';
+//     }
+//     if (status === 'Seen recently') {
+//       return 'warning';
+//     }
+//     if (status === 'Inactive') {
+//       return 'error';
+//     }
+//   }
+
+//   dataGridLocaleText = () => {
+//     const { t } = this.props;
+//     return {
+//       MuiTablePagination: { labelRowsPerPage: t('Orders per page:') },
+//       noRowsLabel: t('No rows'),
+//       noResultsOverlayLabel: t('No results found.'),
+//       errorOverlayDefaultLabel: t('An error occurred.'),
+//       toolbarColumns: t('Columns'),
+//       toolbarColumnsLabel: t('Select columns'),
+//       columnsPanelTextFieldLabel: t('Find column'),
+//       columnsPanelTextFieldPlaceholder: t('Column title'),
+//       columnsPanelDragIconLabel: t('Reorder column'),
+//       columnsPanelShowAllButton: t('Show all'),
+//       columnsPanelHideAllButton: t('Hide all'),
+//       filterPanelAddFilter: t('Add filter'),
+//       filterPanelDeleteIconLabel: t('Delete'),
+//       filterPanelLinkOperator: t('Logic operator'),
+//       filterPanelOperators: t('Operator'), // TODO v6: rename to filterPanelOperator
+//       filterPanelOperatorAnd: t('And'),
+//       filterPanelOperatorOr: t('Or'),
+//       filterPanelColumns: t('Columns'),
+//       filterPanelInputLabel: t('Value'),
+//       filterPanelInputPlaceholder: t('Filter value'),
+//       filterOperatorContains: t('contains'),
+//       filterOperatorEquals: t('equals'),
+//       filterOperatorStartsWith: t('starts with'),
+//       filterOperatorEndsWith: t('ends with'),
+//       filterOperatorIs: t('is'),
+//       filterOperatorNot: t('is not'),
+//       filterOperatorAfter: t('is after'),
+//       filterOperatorOnOrAfter: t('is on or after'),
+//       filterOperatorBefore: t('is before'),
+//       filterOperatorOnOrBefore: t('is on or before'),
+//       filterOperatorIsEmpty: t('is empty'),
+//       filterOperatorIsNotEmpty: t('is not empty'),
+//       filterOperatorIsAnyOf: t('is any of'),
+//       filterValueAny: t('any'),
+//       filterValueTrue: t('true'),
+//       filterValueFalse: t('false'),
+//       columnMenuLabel: t('Menu'),
+//       columnMenuShowColumns: t('Show columns'),
+//       columnMenuFilter: t('Filter'),
+//       columnMenuHideColumn: t('Hide'),
+//       columnMenuUnsort: t('Unsort'),
+//       columnMenuSortAsc: t('Sort by ASC'),
+//       columnMenuSortDesc: t('Sort by DESC'),
+//       columnHeaderFiltersLabel: t('Show filters'),
+//       columnHeaderSortIconLabel: t('Sort'),
+//       booleanCellTrueLabel: t('yes'),
+//       booleanCellFalseLabel: t('no'),
+//     };
+//   };
+
+//   bookListTableDesktop = () => {
+//     const { t } = this.props;
+//     return (
+//       <div style={{ height: 424, width: '100%' }}>
+//         <DataGrid
+//           localeText={this.dataGridLocaleText()}
+//           rows={this.props.bookOrders.filter(
+//             (order) =>
+//               (order.type == this.props.type || this.props.type == null) &&
+//               (order.currency == this.props.currency || this.props.currency == 0),
+//           )}
+//           loading={this.props.bookLoading}
+//           columns={[
+//             // { field: 'id', headerName: 'ID', width: 40 },
+//             {
+//               field: 'maker_nick',
+//               headerName: t('Robot'),
+//               width: 240,
+//               renderCell: (params) => {
+//                 return (
+//                   <ListItemButton style={{ cursor: 'pointer' }}>
+//                     <ListItemAvatar>
+//                       <RobotAvatar
+//                         nickname={params.row.maker_nick}
+//                         style={{ width: 45, height: 45 }}
+//                         smooth={true}
+//                         orderType={params.row.type}
+//                         statusColor={this.statusBadgeColor(params.row.maker_status)}
+//                         tooltip={t(params.row.maker_status)}
+//                       />
+//                     </ListItemAvatar>
+//                     <ListItemText primary={params.row.maker_nick} />
+//                   </ListItemButton>
+//                 );
+//               },
+//             },
+//             {
+//               field: 'type',
+//               headerName: t('Is'),
+//               width: 60,
+//               renderCell: (params) => (params.row.type ? t('Seller') : t('Buyer')),
+//             },
+//             {
+//               field: 'amount',
+//               headerName: t('Amount'),
+//               type: 'number',
+//               width: 90,
+//               renderCell: (params) => {
+//                 return (
+//                   <div style={{ cursor: 'pointer' }}>
+//                     {amountToString(
+//                       params.row.amount,
+//                       params.row.has_range,
+//                       params.row.min_amount,
+//                       params.row.max_amount,
+//                     )}
+//                   </div>
+//                 );
+//               },
+//             },
+//             {
+//               field: 'currency',
+//               headerName: t('Currency'),
+//               width: 100,
+//               renderCell: (params) => {
+//                 const currencyCode = this.getCurrencyCode(params.row.currency);
+//                 return (
+//                   <div
+//                     style={{
+//                       cursor: 'pointer',
+//                       display: 'flex',
+//                       alignItems: 'center',
+//                       flexWrap: 'wrap',
+//                     }}
+//                   >
+//                     {currencyCode + ' '}
+//                     <FlagWithProps code={currencyCode} />
+//                   </div>
+//                 );
+//               },
+//             },
+//             {
+//               field: 'payment_method',
+//               headerName: t('Payment Method'),
+//               width: 180,
+//               renderCell: (params) => {
+//                 return (
+//                   <div style={{ cursor: 'pointer' }}>
+//                     <PaymentText
+//                       othersText={t('Others')}
+//                       verbose={true}
+//                       size={24}
+//                       text={params.row.payment_method}
+//                     />
+//                   </div>
+//                 );
+//               },
+//             },
+//             {
+//               field: 'price',
+//               headerName: t('Price'),
+//               type: 'number',
+//               width: 140,
+//               renderCell: (params) => {
+//                 const currencyCode = this.getCurrencyCode(params.row.currency);
+//                 return (
+//                   <div style={{ cursor: 'pointer' }}>
+//                     {pn(params.row.price) + ' ' + currencyCode + '/BTC'}
+//                   </div>
+//                 );
+//               },
+//             },
+//             {
+//               field: 'premium',
+//               headerName: t('Premium'),
+//               type: 'number',
+//               width: 100,
+//               renderCell: (params) => {
+//                 return (
+//                   <div style={{ cursor: 'pointer' }}>
+//                     {parseFloat(parseFloat(params.row.premium).toFixed(4)) + '%'}
+//                   </div>
+//                 );
+//               },
+//             },
+//           ]}
+//           components={{
+//             NoRowsOverlay: () => (
+//               <Stack height='100%' alignItems='center' justifyContent='center'>
+//                 <div style={{ height: '220px' }} />
+//                 {this.NoOrdersFound()}
+//               </Stack>
+//             ),
+//             NoResultsOverlay: () => (
+//               <Stack height='100%' alignItems='center' justifyContent='center'>
+//                 {t('Filter has no results')}
+//               </Stack>
+//             ),
+//           }}
+//           pageSize={this.props.bookLoading ? 0 : this.state.pageSize}
+//           rowsPerPageOptions={[0, 6, 20, 50]}
+//           onPageSizeChange={(newPageSize) => this.setState({ pageSize: newPageSize })}
+//           onRowClick={(params) => this.handleRowClick(params.row.id)} // Whole row is clickable, but the mouse only looks clickly in some places.
+//         />
+//       </div>
+//     );
+//   };
+
+//   bookListTablePhone = () => {
+//     const { t } = this.props;
+//     return (
+//       <div style={{ height: 424, width: '100%' }}>
+//         <DataGrid
+//           localeText={this.dataGridLocaleText()}
+//           loading={this.props.bookLoading}
+//           rows={this.props.bookOrders.filter(
+//             (order) =>
+//               (order.type == this.props.type || this.props.type == null) &&
+//               (order.currency == this.props.currency || this.props.currency == 0),
+//           )}
+//           columns={[
+//             // { field: 'id', headerName: 'ID', width: 40 },
+//             {
+//               field: 'maker_nick',
+//               headerName: t('Robot'),
+//               width: 64,
+//               renderCell: (params) => {
+//                 return (
+//                   <div style={{ position: 'relative', left: '-5px' }}>
+//                     <RobotAvatar
+//                       nickname={params.row.maker_nick}
+//                       smooth={true}
+//                       style={{ width: 45, height: 45 }}
+//                       orderType={params.row.type}
+//                       statusColor={this.statusBadgeColor(params.row.maker_status)}
+//                       tooltip={t(params.row.maker_status)}
+//                     />
+//                   </div>
+//                 );
+//               },
+//             },
+//             {
+//               field: 'amount',
+//               headerName: t('Amount'),
+//               type: 'number',
+//               width: 84,
+//               renderCell: (params) => {
+//                 return (
+//                   <Tooltip
+//                     placement='right'
+//                     enterTouchDelay={0}
+//                     title={t(params.row.type ? 'Seller' : 'Buyer')}
+//                   >
+//                     <div style={{ cursor: 'pointer' }}>
+//                       {amountToString(
+//                         params.row.amount,
+//                         params.row.has_range,
+//                         params.row.min_amount,
+//                         params.row.max_amount,
+//                       )}
+//                     </div>
+//                   </Tooltip>
+//                 );
+//               },
+//             },
+//             {
+//               field: 'currency',
+//               headerName: t('Currency'),
+//               width: 85,
+//               renderCell: (params) => {
+//                 const currencyCode = this.getCurrencyCode(params.row.currency);
+//                 return (
+//                   <div
+//                     style={{
+//                       cursor: 'pointer',
+//                       display: 'flex',
+//                       alignItems: 'center',
+//                       flexWrap: 'wrap',
+//                     }}
+//                   >
+//                     {currencyCode + ' '}
+//                     <FlagWithProps code={currencyCode} />
+//                   </div>
+//                 );
+//               },
+//             },
+//             { field: 'payment_method', headerName: t('Payment Method'), width: 180, hide: 'true' },
+//             {
+//               field: 'payment_icons',
+//               headerName: t('Pay'),
+//               width: 75,
+//               renderCell: (params) => {
+//                 return (
+//                   <div
+//                     style={{
+//                       position: 'relative',
+//                       left: '-4px',
+//                       cursor: 'pointer',
+//                       align: 'center',
+//                     }}
+//                   >
+//                     <PaymentText
+//                       othersText={t('Others')}
+//                       size={16}
+//                       text={params.row.payment_method}
+//                     />
+//                   </div>
+//                 );
+//               },
+//             },
+//             {
+//               field: 'price',
+//               headerName: t('Price'),
+//               type: 'number',
+//               width: 140,
+//               hide: 'true',
+//               renderCell: (params) => {
+//                 return (
+//                   <div style={{ cursor: 'pointer' }}>
+//                     {pn(params.row.price) + ' ' + params.row.currency + '/BTC'}
+//                   </div>
+//                 );
+//               },
+//             },
+//             {
+//               field: 'premium',
+//               headerName: t('Premium'),
+//               type: 'number',
+//               width: 85,
+//               renderCell: (params) => {
+//                 return (
+//                   <Tooltip
+//                     placement='left'
+//                     enterTouchDelay={0}
+//                     title={pn(params.row.price) + ' ' + params.row.currency + '/BTC'}
+//                   >
+//                     <div style={{ cursor: 'pointer' }}>
+//                       {parseFloat(parseFloat(params.row.premium).toFixed(4)) + '%'}
+//                     </div>
+//                   </Tooltip>
+//                 );
+//               },
+//             },
+//           ]}
+//           components={{
+//             NoRowsOverlay: () => (
+//               <Stack height='100%' alignItems='center' justifyContent='center'>
+//                 <div style={{ height: '220px' }} />
+//                 {this.NoOrdersFound()}
+//               </Stack>
+//             ),
+//             NoResultsOverlay: () => (
+//               <Stack height='100%' alignItems='center' justifyContent='center'>
+//                 {t('Local filter returns no result')}
+//               </Stack>
+//             ),
+//           }}
+//           pageSize={this.props.bookLoading ? 0 : this.state.pageSize}
+//           rowsPerPageOptions={[0, 6, 20, 50]}
+//           onPageSizeChange={(newPageSize) => this.setState({ pageSize: newPageSize })}
+//           onRowClick={(params) => this.handleRowClick(params.row.id)} // Whole row is clickable, but the mouse only looks clickly in some places.
+//         />
+//       </div>
+//     );
+//   };
+
+//   handleTypeChange = (mouseEvent, val) => {
+//     this.props.setAppState({ type: val });
+//   };
+
+//   handleClickView = () => {
+//     this.setState({ view: this.state.view == 'depth' ? 'list' : 'depth' });
+//   };
+
+
+
+//   mainView = () => {
+//     if (this.props.bookNotFound) {
+//       return this.NoOrdersFound();
+//     }
+
+//     const components =
+//       this.state.view == 'depth'
+//         ? [
+//             <DepthChart
+//               bookLoading={this.props.bookLoading}
+//               orders={this.props.bookOrders}
+//               lastDayPremium={this.props.lastDayPremium}
+//               currency={this.props.currency}
+//               setAppState={this.props.setAppState}
+//               limits={this.props.limits}
+//             />,
+//             <DepthChart
+//               bookLoading={this.props.bookLoading}
+//               orders={this.props.bookOrders}
+//               lastDayPremium={this.props.lastDayPremium}
+//               currency={this.props.currency}
+//               compact={true}
+//               setAppState={this.props.setAppState}
+//               limits={this.props.limits}
+//             />,
+//           ]
+//         : [this.bookListTableDesktop(), this.bookListTablePhone()];
+
+//     return (
+//       <>
+//         {/* Desktop */}
+//         <MediaQuery minWidth={930}>
+//           <Paper elevation={0} style={{ width: 925, maxHeight: 510, overflow: 'auto' }}>
+//             <div style={{ height: 424, width: '100%' }}>{components[0]}</div>
+//           </Paper>
+//         </MediaQuery>
+//         {/* Smartphone */}
+//         <MediaQuery maxWidth={929}>
+//           <Paper elevation={0} style={{ width: 395, maxHeight: 460, overflow: 'auto' }}>
+//             <div style={{ height: 424, width: '100%' }}>{components[1]}</div>
+//           </Paper>
+//         </MediaQuery>
+//       </>
+//     );
+//   };
+
+//   getTitle = () => {
+//     const { t } = this.props;
+
+//     if (this.state.view == 'list') {
+//       if (this.props.type == 0) {
+//         return t('You are SELLING BTC for {{currencyCode}}', {
+//           currencyCode: this.props.bookCurrencyCode,
+//         });
+//       } else if (this.props.type == 1) {
+//         return t('You are BUYING BTC for {{currencyCode}}', {
+//           currencyCode: this.props.bookCurrencyCode,
+//         });
+//       } else {
+//         return t('You are looking at all');
+//       }
+//     } else if (this.state.view == 'depth') {
+//       return t('Depth chart');
+//     }
+//   };
+
+//   render() {
+//     const { t } = this.props;
+//     return (
+//       <Grid className='orderBook' container spacing={1} sx={{ minWidth: 400 }}>
+//         <IconButton
+//           sx={{ position: 'fixed', right: '0px', top: '30px' }}
+//           onClick={() => this.setState({ loading: true }) & this.getOrderDetails(2, 0)}
+//         >
+//           <Refresh />
+//         </IconButton>
+
+//         <Grid item xs={6} align='right'>
+//           <FormControl align='center'>
+//             <FormHelperText align='center' sx={{ textAlign: 'center' }}>
+//               {t('I want to')}
+//             </FormHelperText>
+//             <div style={{ textAlign: 'center' }}>
+//               <ToggleButtonGroup
+//                 sx={{ height: '3.52em' }}
+//                 size='large'
+//                 exclusive={true}
+//                 value={this.props.type}
+//                 onChange={this.handleTypeChange}
+//               >
+//                 <ToggleButton value={1} color={'primary'}>
+//                   {t('Buy')}
+//                 </ToggleButton>
+//                 <ToggleButton value={0} color={'secondary'}>
+//                   {t('Sell')}
+//                 </ToggleButton>
+//               </ToggleButtonGroup>
+//             </div>
+//           </FormControl>
+//         </Grid>
+
+//         <Grid item xs={6} align='left'>
+//           <FormControl align='center'>
+//             <FormHelperText
+//               align='center'
+//               sx={{ textAlign: 'center', position: 'relative', left: '-5px' }}
+//             >
+//               {this.props.type == 0
+//                 ? t('and receive')
+//                 : this.props.type == 1
+//                 ? t('and pay with')
+//                 : t('and use')}
+//             </FormHelperText>
+//             <Select
+//               // autoWidth={true}
+//               sx={{ width: 120 }}
+//               label={t('Select Payment Currency')}
+//               required={true}
+//               value={this.props.currency}
+//               inputProps={{
+//                 style: { textAlign: 'center' },
+//               }}
+//               onChange={this.handleCurrencyChange}
+//             >
+//               <MenuItem value={0}>
+//                 <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
+//                   <FlagWithProps code='ANY' />
+//                   {' ' + t('ANY_currency')}
+//                 </div>
+//               </MenuItem>
+//               {Object.entries(currencyDict).map(([key, value]) => (
+//                 <MenuItem key={key} value={parseInt(key)}>
+//                   <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
+//                     <FlagWithProps code={value} />
+//                     {' ' + value}
+//                   </div>
+//                 </MenuItem>
+//               ))}
+//             </Select>
+//           </FormControl>
+//         </Grid>
+//         {this.props.bookNotFound ? (
+//           <></>
+//         ) : (
+//           <Grid item xs={12} align='center'>
+//             <Typography component='h5' variant='h5'>
+//               {this.getTitle()}
+//             </Typography>
+//           </Grid>
+//         )}
+//         <Grid item xs={12} align='center'>
+//           {this.mainView()}
+//         </Grid>
+//         <Grid item xs={12} align='center'>
+//           <ButtonGroup variant='contained' aria-label='outlined primary button group'>
+//             {!this.props.bookNotFound ? (
+//               <>
+//                 <Button variant='contained' color='primary' to='/make/' component={Link}>
+//                   {t('Make Order')}
+//                 </Button>
+//                 <Button color='inherit' style={{ color: '#111111' }} onClick={this.handleClickView}>
+//                   {this.state.view == 'depth' ? (
+//                     <>
+//                       <FormatListBulleted /> {t('List')}
+//                     </>
+//                   ) : (
+//                     <>
+//                       <BarChart /> {t('Chart')}
+//                     </>
+//                   )}
+//                 </Button>
+//               </>
+//             ) : null}
+//             <Button color='secondary' variant='contained' to='/' component={Link}>
+//               {t('Back')}
+//             </Button>
+//           </ButtonGroup>
+//         </Grid>
+//       </Grid>h
+//     );
+//   }
+// }
+
+// export default withTranslation()(BookPage);

--- a/frontend/src/components/BookTable.tsx
+++ b/frontend/src/components/BookTable.tsx
@@ -57,7 +57,7 @@ function mixColors(baseColor: string, accentColor: string, point: number) {
   const green = baseRGB[1] + greenDiff * point;
   const blueDiff = accentRGB[2] - baseRGB[2];
   const blue = baseRGB[2] + blueDiff * point;
-  return `rgb(${Math.round(red)}, ${Math.round(green)}, ${Math.round(blue)}, ${0.7 + point*0.3})`;
+  return `rgb(${Math.round(red)}, ${Math.round(green)}, ${Math.round(blue)}, ${0.7 + point * 0.3})`;
 }
 
 function localizeDataGrid() {
@@ -152,13 +152,13 @@ const BookTable = ({
 
   const robotObj = function (width: number, hide: boolean) {
     return {
-      hide: hide,
+      hide,
       field: 'maker_nick',
       headerName: t('Robot'),
       width: width * fontSize,
       renderCell: (params) => {
         return (
-          <ListItemButton style={{ cursor: 'pointer', position: 'relative', left: '-1.3em'}}>
+          <ListItemButton style={{ cursor: 'pointer', position: 'relative', left: '-1.3em' }}>
             <ListItemAvatar>
               <RobotAvatar
                 nickname={params.row.maker_nick}
@@ -178,7 +178,7 @@ const BookTable = ({
 
   const robotSmallObj = function (width: number, hide: boolean) {
     return {
-      hide: hide,
+      hide,
       field: 'maker_nick',
       headerName: t('Robot'),
       width: width * fontSize,
@@ -203,7 +203,7 @@ const BookTable = ({
 
   const typeObj = function (width: number, hide: boolean) {
     return {
-      hide: hide,
+      hide,
       field: 'type',
       headerName: t('Is'),
       width: width * fontSize,
@@ -213,7 +213,7 @@ const BookTable = ({
 
   const amountObj = function (width: number, hide: boolean) {
     return {
-      hide: hide,
+      hide,
       field: 'amount',
       headerName: t('Amount'),
       type: 'number',
@@ -235,7 +235,7 @@ const BookTable = ({
 
   const currencyObj = function (width: number, hide: boolean) {
     return {
-      hide: hide,
+      hide,
       field: 'currency',
       headerName: t('Currency'),
       width: width * fontSize,
@@ -260,7 +260,7 @@ const BookTable = ({
 
   const paymentObj = function (width: number, hide: boolean) {
     return {
-      hide: hide,
+      hide,
       field: 'payment_method',
       headerName: t('Payment Method'),
       width: width * fontSize,
@@ -281,7 +281,7 @@ const BookTable = ({
 
   const paymentSmallObj = function (width: number, hide: boolean) {
     return {
-      hide: hide,
+      hide,
       field: 'payment_icons',
       headerName: t('Pay'),
       width: width * fontSize,
@@ -308,7 +308,7 @@ const BookTable = ({
 
   const priceObj = function (width: number, hide: boolean) {
     return {
-      hide: hide,
+      hide,
       field: 'price',
       headerName: t('Price'),
       type: 'number',
@@ -329,7 +329,7 @@ const BookTable = ({
     const sellStandardPremium = 10;
     const buyOutstandingPremium = 10;
     return {
-      hide: hide,
+      hide,
       field: 'premium',
       headerName: t('Premium'),
       type: 'number',
@@ -356,7 +356,7 @@ const BookTable = ({
         const fontWeight = 400 + Math.round(premiumPoint * 5) * 100;
         return (
           <div style={{ cursor: 'pointer' }}>
-            <Typography variant='inherit' color={fontColor} sx={{ fontWeight: fontWeight }}>
+            <Typography variant='inherit' color={fontColor} sx={{ fontWeight }}>
               {parseFloat(parseFloat(params.row.premium).toFixed(4)) + '%'}
             </Typography>
           </div>
@@ -367,7 +367,7 @@ const BookTable = ({
 
   const timerObj = function (width: number, hide: boolean) {
     return {
-      hide: hide,
+      hide,
       field: 'escrow_duration',
       headerName: t('Timer'),
       type: 'number',
@@ -375,18 +375,14 @@ const BookTable = ({
       renderCell: (params) => {
         const hours = Math.round(params.row.escrow_duration / 3600);
         const minutes = Math.round((params.row.escrow_duration - hours * 3600) / 60);
-        return (
-          <div style={{ cursor: 'pointer' }}>
-            {hours > 0 ? `${hours}h` : `${minutes}m`}
-          </div>
-        );
+        return <div style={{ cursor: 'pointer' }}>{hours > 0 ? `${hours}h` : `${minutes}m`}</div>;
       },
     };
   };
 
   const expiryObj = function (width: number, hide: boolean) {
     return {
-      hide: hide,
+      hide,
       field: 'expires_at',
       headerName: t('Expiry'),
       type: 'string',
@@ -430,7 +426,7 @@ const BookTable = ({
 
   const satoshisObj = function (width: number, hide: boolean) {
     return {
-      hide: hide,
+      hide,
       field: 'satoshis_now',
       headerName: t('Sats now'),
       type: 'number',
@@ -447,7 +443,7 @@ const BookTable = ({
 
   const idObj = function (width: number, hide: boolean) {
     return {
-      hide: hide,
+      hide,
       field: 'id',
       headerName: 'Order ID',
       width: width * fontSize,

--- a/frontend/src/components/BookTable.tsx
+++ b/frontend/src/components/BookTable.tsx
@@ -57,7 +57,7 @@ function mixColors(baseColor: string, accentColor: string, point: number) {
   const green = baseRGB[1] + greenDiff * point;
   const blueDiff = accentRGB[2] - baseRGB[2];
   const blue = baseRGB[2] + blueDiff * point;
-  return `rgb(${Math.round(red)}, ${Math.round(green)}, ${Math.round(blue)})`;
+  return `rgb(${Math.round(red)}, ${Math.round(green)}, ${Math.round(blue)}, ${0.7 + point*0.3})`;
 }
 
 function localizeDataGrid() {
@@ -158,7 +158,7 @@ const BookTable = ({
       width: width * fontSize,
       renderCell: (params) => {
         return (
-          <ListItemButton style={{ cursor: 'pointer' }}>
+          <ListItemButton style={{ cursor: 'pointer', position: 'relative', left: '-1.3em'}}>
             <ListItemAvatar>
               <RobotAvatar
                 nickname={params.row.maker_nick}
@@ -184,7 +184,7 @@ const BookTable = ({
       width: width * fontSize,
       renderCell: (params) => {
         return (
-          <div style={{ position: 'relative', left: '-1.75em' }}>
+          <div style={{ position: 'relative', left: '-1.5em' }}>
             <ListItemButton style={{ cursor: 'pointer' }}>
               <RobotAvatar
                 nickname={params.row.maker_nick}
@@ -341,7 +341,7 @@ const BookTable = ({
           premiumPoint = premiumPoint < 0 ? 0 : premiumPoint > 1 ? 1 : premiumPoint;
           fontColor = mixColors(
             theme.palette.text.primary,
-            theme.palette.secondary.main,
+            theme.palette.secondary.dark,
             premiumPoint,
           );
         } else {
@@ -349,7 +349,7 @@ const BookTable = ({
           premiumPoint = premiumPoint < 0 ? 0 : premiumPoint > 1 ? 1 : premiumPoint;
           fontColor = mixColors(
             theme.palette.text.primary,
-            theme.palette.primary.main,
+            theme.palette.primary.dark,
             premiumPoint,
           );
         }
@@ -377,8 +377,7 @@ const BookTable = ({
         const minutes = Math.round((params.row.escrow_duration - hours * 3600) / 60);
         return (
           <div style={{ cursor: 'pointer' }}>
-            {hours > 0 ? hours + 'h' : ''}{' '}
-            {minutes > 0 ? String(minutes).padStart(2, '0') + 'm' : ''}
+            {hours > 0 ? `${hours}h` : `${minutes}m`}
           </div>
         );
       },
@@ -471,7 +470,7 @@ const BookTable = ({
       priority: 2,
       order: 5,
       normal: {
-        width: 7,
+        width: 5.8,
         object: currencyObj,
       },
     },
@@ -491,7 +490,7 @@ const BookTable = ({
         object: robotObj,
       },
       small: {
-        width: 4.5,
+        width: 4.3,
         object: robotSmallObj,
       },
     },
@@ -527,7 +526,7 @@ const BookTable = ({
       priority: 8,
       order: 8,
       normal: {
-        width: 4,
+        width: 3.8,
         object: timerObj,
       },
     },

--- a/frontend/src/components/BookTable.tsx
+++ b/frontend/src/components/BookTable.tsx
@@ -451,7 +451,13 @@ const BookTable = ({
       headerName: 'Order ID',
       width: width * fontSize,
       renderCell: (params) => {
-        return <div style={{ cursor: 'pointer' }}>{pn(params.row.id)}</div>;
+        return (
+          <div style={{ cursor: 'pointer' }}>
+            <Typography variant='caption' color='text.secondary'>
+              {`#${params.row.id}`}
+            </Typography>
+          </div>
+        );
       },
     };
   };
@@ -547,9 +553,9 @@ const BookTable = ({
     },
     id: {
       priority: 11,
-      order: 3,
+      order: 12,
       normal: {
-        width: 5,
+        width: 4.8,
         object: idObj,
       },
     },

--- a/frontend/src/components/BookTable.tsx
+++ b/frontend/src/components/BookTable.tsx
@@ -139,7 +139,10 @@ const BookTable = ({
   // all sizes in 'em'
   const verticalHeightFrame = 6.9075;
   const verticalHeightRow = 3.25;
-  const defaultPageSize = Math.floor((maxHeight - verticalHeightFrame) / verticalHeightRow);
+  const defaultPageSize = Math.max(
+    Math.floor((maxHeight - verticalHeightFrame) / verticalHeightRow),
+    1,
+  );
   const height = defaultPageSize * verticalHeightRow + verticalHeightFrame;
 
   const [pageSize, setPageSize] = useState(0);
@@ -553,13 +556,13 @@ const BookTable = ({
   };
 
   const filteredColumns = function (maxWidth: number) {
-    const small = maxWidth < 70;
+    const useSmall = maxWidth < 70;
     const selectedColumns: object[] = [];
     let width: number = 0;
 
     for (const [key, value] of Object.entries(columnSpecs)) {
-      const colWidth = small && value.small ? value.small.width : value.normal.width;
-      const colObject = small && value.small ? value.small.object : value.normal.object;
+      const colWidth = useSmall && value.small ? value.small.width : value.normal.width;
+      const colObject = useSmall && value.small ? value.small.object : value.normal.object;
 
       if (width + colWidth < maxWidth || selectedColumns.length < 2) {
         width = width + colWidth;

--- a/frontend/src/components/Charts/DepthChart/index.tsx
+++ b/frontend/src/components/Charts/DepthChart/index.tsx
@@ -38,7 +38,8 @@ interface DepthChartProps {
   currency: number;
   setAppState: (state: object) => void;
   limits: LimitList;
-  compact?: boolean;
+  maxWidth: number;
+  maxHeight: number;
 }
 
 const DepthChart: React.FC<DepthChartProps> = ({
@@ -48,7 +49,8 @@ const DepthChart: React.FC<DepthChartProps> = ({
   currency,
   setAppState,
   limits,
-  compact,
+  maxWidth,
+  maxHeight
 }) => {
   const { t } = useTranslation();
   const history = useHistory();
@@ -60,6 +62,9 @@ const DepthChart: React.FC<DepthChartProps> = ({
   const [xType, setXType] = useState<string>('premium');
   const [currencyCode, setCurrencyCode] = useState<number>(1);
   const [center, setCenter] = useState<number>();
+
+  const height = maxHeight < 20 ? 20 : maxHeight
+  const width = maxWidth < 20 ? 20 : maxWidth
 
   useEffect(() => {
     if (Object.keys(limits).length === 0) {
@@ -293,10 +298,9 @@ const DepthChart: React.FC<DepthChartProps> = ({
   };
 
   return (
-    <Paper elevation={2} style={{ width: 925, maxHeight: 510, overflow: 'auto' }}>
-      <div style={{ height: 424, width: '100%' }}>
+    <Paper style={{ width: `${width}em`, maxHeight: `${height}em` }}>
         {bookLoading || center == undefined || enrichedOrders.length < 1 ? (
-          <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 200, height: 420 }}>
+          <div style={{ display: 'flex', justifyContent: 'center', paddingTop: `${height/2-1}em`, height:  `${height}em`}}>
             <CircularProgress />
           </div>
         ) : (
@@ -349,7 +353,7 @@ const DepthChart: React.FC<DepthChartProps> = ({
                 </Grid>
               </Grid>
             </Grid>
-            <Grid container style={{ height: 357, padding: 15 }}>
+            <Grid container style={{ height: `${height - 7}em`, padding: 15 }}>
               <ResponsiveLine
                 data={series}
                 enableArea={true}
@@ -368,10 +372,10 @@ const DepthChart: React.FC<DepthChartProps> = ({
                 }}
                 axisBottom={{
                   tickSize: 5,
-                  tickRotation: xType === 'base_amount' && compact ? 45 : 0,
+                  tickRotation: xType === 'base_amount' && width < 40 ? 45 : 0,
                   format: formatAxisX,
                 }}
-                margin={{ left: 65, right: 60, bottom: compact ? 36 : 25, top: 10 }}
+                margin={{ left: 65, right: 60, bottom: width < 40 ? 36 : 25, top: 10 }}
                 xFormat={(value) => Number(value).toFixed(0)}
                 lineWidth={3}
                 theme={getNivoScheme(theme)}
@@ -386,7 +390,6 @@ const DepthChart: React.FC<DepthChartProps> = ({
             </Grid>
           </Grid>
         )}
-      </div>
     </Paper>
   );
 };

--- a/frontend/src/components/Charts/DepthChart/index.tsx
+++ b/frontend/src/components/Charts/DepthChart/index.tsx
@@ -30,6 +30,7 @@ import PaymentText from '../../PaymentText';
 import getNivoScheme from '../NivoScheme';
 import median from '../../../utils/match';
 import { apiClient } from '../../../services/api/index';
+import statusBadgeColor from '../../../utils/statusBadgeColor';
 
 interface DepthChartProps {
   bookLoading: boolean;
@@ -220,16 +221,6 @@ const DepthChart: React.FC<DepthChartProps> = ({
       strokeWidth={getNivoScheme(theme).markers?.lineStrokeWidth}
     />
   );
-
-  const statusBadgeColor = (status: string) => {
-    if (status === 'Active') {
-      return 'success';
-    }
-    if (status === 'Seen recently') {
-      return 'warning';
-    }
-    return 'error';
-  };
 
   const generateTooltip: React.FunctionComponent<PointTooltipProps> = (
     pointTooltip: PointTooltipProps,

--- a/frontend/src/components/Charts/DepthChart/index.tsx
+++ b/frontend/src/components/Charts/DepthChart/index.tsx
@@ -304,8 +304,8 @@ const DepthChart: React.FC<DepthChartProps> = ({
           style={{
             display: 'flex',
             justifyContent: 'center',
-            paddingTop: `${height / 2 - 1}em`,
-            height: `${height}em`,
+            paddingTop: `${(height - 3) / 2 - 1}em`,
+            height: `${height - 3}em`,
           }}
         >
           <CircularProgress />

--- a/frontend/src/components/Charts/DepthChart/index.tsx
+++ b/frontend/src/components/Charts/DepthChart/index.tsx
@@ -223,7 +223,6 @@ const DepthChart: React.FC<DepthChartProps> = ({
     if (status === 'Seen recently') {
       return 'warning';
     }
-
     return 'error';
   };
 
@@ -293,94 +292,102 @@ const DepthChart: React.FC<DepthChartProps> = ({
     history.push('/order/' + point.data?.order?.id);
   };
 
-  return bookLoading || center == undefined || enrichedOrders.length < 1 ? (
-    <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 200, height: 420 }}>
-      <CircularProgress />
-    </div>
-  ) : (
-    <Grid container style={{ paddingTop: 15 }}>
-      <Grid
-        container
-        direction='row'
-        justifyContent='space-around'
-        alignItems='flex-start'
-        style={{ position: 'absolute' }}
-      >
-        <Grid
-          container
-          justifyContent='flex-start'
-          alignItems='flex-start'
-          style={{ paddingLeft: 20 }}
-        >
-          <Select variant='standard' value={xType} onChange={(e) => setXType(e.target.value)}>
-            <MenuItem value={'premium'}>
-              <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
-                {t('Premium')}
-              </div>
-            </MenuItem>
-            <MenuItem value={'base_amount'}>
-              <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
-                {t('Price')}
-              </div>
-            </MenuItem>
-          </Select>
-        </Grid>
-      </Grid>
-      <Grid container direction='row' justifyContent='center' alignItems='center'>
-        <Grid container justifyContent='center' alignItems='center'>
-          <Grid item>
-            <IconButton onClick={() => setXRange(xRange + rangeSteps)}>
-              <RemoveCircleOutline />
-            </IconButton>
+  return (
+    <Paper elevation={2} style={{ width: 925, maxHeight: 510, overflow: 'auto' }}>
+      <div style={{ height: 424, width: '100%' }}>
+        {bookLoading || center == undefined || enrichedOrders.length < 1 ? (
+          <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 200, height: 420 }}>
+            <CircularProgress />
+          </div>
+        ) : (
+          <Grid container style={{ paddingTop: 15 }}>
+            <Grid
+              container
+              direction='row'
+              justifyContent='space-around'
+              alignItems='flex-start'
+              style={{ position: 'absolute' }}
+            >
+              <Grid
+                container
+                justifyContent='flex-start'
+                alignItems='flex-start'
+                style={{ paddingLeft: 20 }}
+              >
+                <Select variant='standard' value={xType} onChange={(e) => setXType(e.target.value)}>
+                  <MenuItem value={'premium'}>
+                    <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
+                      {t('Premium')}
+                    </div>
+                  </MenuItem>
+                  <MenuItem value={'base_amount'}>
+                    <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
+                      {t('Price')}
+                    </div>
+                  </MenuItem>
+                </Select>
+              </Grid>
+            </Grid>
+            <Grid container direction='row' justifyContent='center' alignItems='center'>
+              <Grid container justifyContent='center' alignItems='center'>
+                <Grid item>
+                  <IconButton onClick={() => setXRange(xRange + rangeSteps)}>
+                    <RemoveCircleOutline />
+                  </IconButton>
+                </Grid>
+                <Grid item>
+                  <Box justifyContent='center'>
+                    {xType === 'base_amount'
+                      ? `${center} ${currencyDict[currencyCode]}`
+                      : `${center}%`}
+                  </Box>
+                </Grid>
+                <Grid item>
+                  <IconButton onClick={() => setXRange(xRange - rangeSteps)} disabled={xRange <= 1}>
+                    <AddCircleOutline />
+                  </IconButton>
+                </Grid>
+              </Grid>
+            </Grid>
+            <Grid container style={{ height: 357, padding: 15 }}>
+              <ResponsiveLine
+                data={series}
+                enableArea={true}
+                useMesh={true}
+                animate={false}
+                crosshairType='cross'
+                tooltip={generateTooltip}
+                onClick={handleOnClick}
+                axisRight={{
+                  tickSize: 5,
+                  format: formatAxisY,
+                }}
+                axisLeft={{
+                  tickSize: 5,
+                  format: formatAxisY,
+                }}
+                axisBottom={{
+                  tickSize: 5,
+                  tickRotation: xType === 'base_amount' && compact ? 45 : 0,
+                  format: formatAxisX,
+                }}
+                margin={{ left: 65, right: 60, bottom: compact ? 36 : 25, top: 10 }}
+                xFormat={(value) => Number(value).toFixed(0)}
+                lineWidth={3}
+                theme={getNivoScheme(theme)}
+                colors={[theme.palette.secondary.main, theme.palette.primary.main]}
+                xScale={{
+                  type: 'linear',
+                  min: center - xRange,
+                  max: center + xRange,
+                }}
+                layers={['axes', 'areas', 'crosshair', 'lines', centerLine, 'slices', 'mesh']}
+              />
+            </Grid>
           </Grid>
-          <Grid item>
-            <Box justifyContent='center'>
-              {xType === 'base_amount' ? `${center} ${currencyDict[currencyCode]}` : `${center}%`}
-            </Box>
-          </Grid>
-          <Grid item>
-            <IconButton onClick={() => setXRange(xRange - rangeSteps)} disabled={xRange <= 1}>
-              <AddCircleOutline />
-            </IconButton>
-          </Grid>
-        </Grid>
-      </Grid>
-      <Grid container style={{ height: 357, padding: 15 }}>
-        <ResponsiveLine
-          data={series}
-          enableArea={true}
-          useMesh={true}
-          animate={false}
-          crosshairType='cross'
-          tooltip={generateTooltip}
-          onClick={handleOnClick}
-          axisRight={{
-            tickSize: 5,
-            format: formatAxisY,
-          }}
-          axisLeft={{
-            tickSize: 5,
-            format: formatAxisY,
-          }}
-          axisBottom={{
-            tickSize: 5,
-            tickRotation: xType === 'base_amount' && compact ? 45 : 0,
-            format: formatAxisX,
-          }}
-          margin={{ left: 65, right: 60, bottom: compact ? 36 : 25, top: 10 }}
-          xFormat={(value) => Number(value).toFixed(0)}
-          lineWidth={3}
-          theme={getNivoScheme(theme)}
-          colors={[theme.palette.secondary.main, theme.palette.primary.main]}
-          xScale={{
-            type: 'linear',
-            min: center - xRange,
-            max: center + xRange,
-          }}
-          layers={['axes', 'areas', 'crosshair', 'lines', centerLine, 'slices', 'mesh']}
-        />
-      </Grid>
-    </Grid>
+        )}
+      </div>
+    </Paper>
   );
 };
 

--- a/frontend/src/components/Charts/DepthChart/index.tsx
+++ b/frontend/src/components/Charts/DepthChart/index.tsx
@@ -50,7 +50,7 @@ const DepthChart: React.FC<DepthChartProps> = ({
   setAppState,
   limits,
   maxWidth,
-  maxHeight
+  maxHeight,
 }) => {
   const { t } = useTranslation();
   const history = useHistory();
@@ -63,8 +63,8 @@ const DepthChart: React.FC<DepthChartProps> = ({
   const [currencyCode, setCurrencyCode] = useState<number>(1);
   const [center, setCenter] = useState<number>();
 
-  const height = maxHeight < 20 ? 20 : maxHeight
-  const width = maxWidth < 20 ? 20 : maxWidth
+  const height = maxHeight < 20 ? 20 : maxHeight;
+  const width = maxWidth < 20 ? 20 : maxWidth;
 
   useEffect(() => {
     if (Object.keys(limits).length === 0) {
@@ -299,97 +299,104 @@ const DepthChart: React.FC<DepthChartProps> = ({
 
   return (
     <Paper style={{ width: `${width}em`, maxHeight: `${height}em` }}>
-        {bookLoading || center == undefined || enrichedOrders.length < 1 ? (
-          <div style={{ display: 'flex', justifyContent: 'center', paddingTop: `${height/2-1}em`, height:  `${height}em`}}>
-            <CircularProgress />
-          </div>
-        ) : (
-          <Grid container style={{ paddingTop: 15 }}>
+      {bookLoading || center == undefined || enrichedOrders.length < 1 ? (
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            paddingTop: `${height / 2 - 1}em`,
+            height: `${height}em`,
+          }}
+        >
+          <CircularProgress />
+        </div>
+      ) : (
+        <Grid container style={{ paddingTop: 15 }}>
+          <Grid
+            container
+            direction='row'
+            justifyContent='space-around'
+            alignItems='flex-start'
+            style={{ position: 'absolute' }}
+          >
             <Grid
               container
-              direction='row'
-              justifyContent='space-around'
+              justifyContent='flex-start'
               alignItems='flex-start'
-              style={{ position: 'absolute' }}
+              style={{ paddingLeft: 20 }}
             >
-              <Grid
-                container
-                justifyContent='flex-start'
-                alignItems='flex-start'
-                style={{ paddingLeft: 20 }}
-              >
-                <Select variant='standard' value={xType} onChange={(e) => setXType(e.target.value)}>
-                  <MenuItem value={'premium'}>
-                    <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
-                      {t('Premium')}
-                    </div>
-                  </MenuItem>
-                  <MenuItem value={'base_amount'}>
-                    <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
-                      {t('Price')}
-                    </div>
-                  </MenuItem>
-                </Select>
-              </Grid>
-            </Grid>
-            <Grid container direction='row' justifyContent='center' alignItems='center'>
-              <Grid container justifyContent='center' alignItems='center'>
-                <Grid item>
-                  <IconButton onClick={() => setXRange(xRange + rangeSteps)}>
-                    <RemoveCircleOutline />
-                  </IconButton>
-                </Grid>
-                <Grid item>
-                  <Box justifyContent='center'>
-                    {xType === 'base_amount'
-                      ? `${center} ${currencyDict[currencyCode]}`
-                      : `${center}%`}
-                  </Box>
-                </Grid>
-                <Grid item>
-                  <IconButton onClick={() => setXRange(xRange - rangeSteps)} disabled={xRange <= 1}>
-                    <AddCircleOutline />
-                  </IconButton>
-                </Grid>
-              </Grid>
-            </Grid>
-            <Grid container style={{ height: `${height - 7}em`, padding: 15 }}>
-              <ResponsiveLine
-                data={series}
-                enableArea={true}
-                useMesh={true}
-                animate={false}
-                crosshairType='cross'
-                tooltip={generateTooltip}
-                onClick={handleOnClick}
-                axisRight={{
-                  tickSize: 5,
-                  format: formatAxisY,
-                }}
-                axisLeft={{
-                  tickSize: 5,
-                  format: formatAxisY,
-                }}
-                axisBottom={{
-                  tickSize: 5,
-                  tickRotation: xType === 'base_amount' && width < 40 ? 45 : 0,
-                  format: formatAxisX,
-                }}
-                margin={{ left: 65, right: 60, bottom: width < 40 ? 36 : 25, top: 10 }}
-                xFormat={(value) => Number(value).toFixed(0)}
-                lineWidth={3}
-                theme={getNivoScheme(theme)}
-                colors={[theme.palette.secondary.main, theme.palette.primary.main]}
-                xScale={{
-                  type: 'linear',
-                  min: center - xRange,
-                  max: center + xRange,
-                }}
-                layers={['axes', 'areas', 'crosshair', 'lines', centerLine, 'slices', 'mesh']}
-              />
+              <Select variant='standard' value={xType} onChange={(e) => setXType(e.target.value)}>
+                <MenuItem value={'premium'}>
+                  <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
+                    {t('Premium')}
+                  </div>
+                </MenuItem>
+                <MenuItem value={'base_amount'}>
+                  <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
+                    {t('Price')}
+                  </div>
+                </MenuItem>
+              </Select>
             </Grid>
           </Grid>
-        )}
+          <Grid container direction='row' justifyContent='center' alignItems='center'>
+            <Grid container justifyContent='center' alignItems='center'>
+              <Grid item>
+                <IconButton onClick={() => setXRange(xRange + rangeSteps)}>
+                  <RemoveCircleOutline />
+                </IconButton>
+              </Grid>
+              <Grid item>
+                <Box justifyContent='center'>
+                  {xType === 'base_amount'
+                    ? `${center} ${currencyDict[currencyCode]}`
+                    : `${center}%`}
+                </Box>
+              </Grid>
+              <Grid item>
+                <IconButton onClick={() => setXRange(xRange - rangeSteps)} disabled={xRange <= 1}>
+                  <AddCircleOutline />
+                </IconButton>
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid container style={{ height: `${height - 7}em`, padding: 15 }}>
+            <ResponsiveLine
+              data={series}
+              enableArea={true}
+              useMesh={true}
+              animate={false}
+              crosshairType='cross'
+              tooltip={generateTooltip}
+              onClick={handleOnClick}
+              axisRight={{
+                tickSize: 5,
+                format: formatAxisY,
+              }}
+              axisLeft={{
+                tickSize: 5,
+                format: formatAxisY,
+              }}
+              axisBottom={{
+                tickSize: 5,
+                tickRotation: xType === 'base_amount' && width < 40 ? 45 : 0,
+                format: formatAxisX,
+              }}
+              margin={{ left: 65, right: 60, bottom: width < 40 ? 36 : 25, top: 10 }}
+              xFormat={(value) => Number(value).toFixed(0)}
+              lineWidth={3}
+              theme={getNivoScheme(theme)}
+              colors={[theme.palette.secondary.main, theme.palette.primary.main]}
+              xScale={{
+                type: 'linear',
+                min: center - xRange,
+                max: center + xRange,
+              }}
+              layers={['axes', 'areas', 'crosshair', 'lines', centerLine, 'slices', 'mesh']}
+            />
+          </Grid>
+        </Grid>
+      )}
     </Paper>
   );
 };

--- a/frontend/src/components/Charts/DepthChart/index.tsx
+++ b/frontend/src/components/Charts/DepthChart/index.tsx
@@ -64,7 +64,7 @@ const DepthChart: React.FC<DepthChartProps> = ({
   const [center, setCenter] = useState<number>();
 
   const height = maxHeight < 20 ? 20 : maxHeight;
-  const width = maxWidth < 20 ? 20 : maxWidth;
+  const width = maxWidth < 20 ? 20 : maxWidth > 72.8 ? 72.8 : maxWidth;
 
   useEffect(() => {
     if (Object.keys(limits).length === 0) {
@@ -299,104 +299,106 @@ const DepthChart: React.FC<DepthChartProps> = ({
 
   return (
     <Paper style={{ width: `${width}em`, maxHeight: `${height}em` }}>
-      {bookLoading || center == undefined || enrichedOrders.length < 1 ? (
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            paddingTop: `${(height - 3) / 2 - 1}em`,
-            height: `${height - 3}em`,
-          }}
-        >
-          <CircularProgress />
-        </div>
-      ) : (
-        <Grid container style={{ paddingTop: 15 }}>
-          <Grid
-            container
-            direction='row'
-            justifyContent='space-around'
-            alignItems='flex-start'
-            style={{ position: 'absolute' }}
+      <Paper variant='outlined'>
+        {bookLoading || center == undefined || enrichedOrders.length < 1 ? (
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'center',
+              paddingTop: `${(height - 3) / 2 - 1}em`,
+              height: `${height - 3}em`,
+            }}
           >
+            <CircularProgress />
+          </div>
+        ) : (
+          <Grid container style={{ paddingTop: 15 }}>
             <Grid
               container
-              justifyContent='flex-start'
+              direction='row'
+              justifyContent='space-around'
               alignItems='flex-start'
-              style={{ paddingLeft: 20 }}
+              style={{ position: 'absolute' }}
             >
-              <Select variant='standard' value={xType} onChange={(e) => setXType(e.target.value)}>
-                <MenuItem value={'premium'}>
-                  <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
-                    {t('Premium')}
-                  </div>
-                </MenuItem>
-                <MenuItem value={'base_amount'}>
-                  <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
-                    {t('Price')}
-                  </div>
-                </MenuItem>
-              </Select>
-            </Grid>
-          </Grid>
-          <Grid container direction='row' justifyContent='center' alignItems='center'>
-            <Grid container justifyContent='center' alignItems='center'>
-              <Grid item>
-                <IconButton onClick={() => setXRange(xRange + rangeSteps)}>
-                  <RemoveCircleOutline />
-                </IconButton>
-              </Grid>
-              <Grid item>
-                <Box justifyContent='center'>
-                  {xType === 'base_amount'
-                    ? `${center} ${currencyDict[currencyCode]}`
-                    : `${center}%`}
-                </Box>
-              </Grid>
-              <Grid item>
-                <IconButton onClick={() => setXRange(xRange - rangeSteps)} disabled={xRange <= 1}>
-                  <AddCircleOutline />
-                </IconButton>
+              <Grid
+                container
+                justifyContent='flex-start'
+                alignItems='flex-start'
+                style={{ paddingLeft: 20 }}
+              >
+                <Select variant='standard' value={xType} onChange={(e) => setXType(e.target.value)}>
+                  <MenuItem value={'premium'}>
+                    <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
+                      {t('Premium')}
+                    </div>
+                  </MenuItem>
+                  <MenuItem value={'base_amount'}>
+                    <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
+                      {t('Price')}
+                    </div>
+                  </MenuItem>
+                </Select>
               </Grid>
             </Grid>
+            <Grid container direction='row' justifyContent='center' alignItems='center'>
+              <Grid container justifyContent='center' alignItems='center'>
+                <Grid item>
+                  <IconButton onClick={() => setXRange(xRange + rangeSteps)}>
+                    <RemoveCircleOutline />
+                  </IconButton>
+                </Grid>
+                <Grid item>
+                  <Box justifyContent='center'>
+                    {xType === 'base_amount'
+                      ? `${center} ${currencyDict[currencyCode]}`
+                      : `${center}%`}
+                  </Box>
+                </Grid>
+                <Grid item>
+                  <IconButton onClick={() => setXRange(xRange - rangeSteps)} disabled={xRange <= 1}>
+                    <AddCircleOutline />
+                  </IconButton>
+                </Grid>
+              </Grid>
+            </Grid>
+            <Grid container style={{ height: `${height - 7}em`, padding: 15 }}>
+              <ResponsiveLine
+                data={series}
+                enableArea={true}
+                useMesh={true}
+                animate={false}
+                crosshairType='cross'
+                tooltip={generateTooltip}
+                onClick={handleOnClick}
+                axisRight={{
+                  tickSize: 5,
+                  format: formatAxisY,
+                }}
+                axisLeft={{
+                  tickSize: 5,
+                  format: formatAxisY,
+                }}
+                axisBottom={{
+                  tickSize: 5,
+                  tickRotation: xType === 'base_amount' && width < 40 ? 45 : 0,
+                  format: formatAxisX,
+                }}
+                margin={{ left: 65, right: 60, bottom: width < 40 ? 36 : 25, top: 10 }}
+                xFormat={(value) => Number(value).toFixed(0)}
+                lineWidth={3}
+                theme={getNivoScheme(theme)}
+                colors={[theme.palette.secondary.main, theme.palette.primary.main]}
+                xScale={{
+                  type: 'linear',
+                  min: center - xRange,
+                  max: center + xRange,
+                }}
+                layers={['axes', 'areas', 'crosshair', 'lines', centerLine, 'slices', 'mesh']}
+              />
+            </Grid>
           </Grid>
-          <Grid container style={{ height: `${height - 7}em`, padding: 15 }}>
-            <ResponsiveLine
-              data={series}
-              enableArea={true}
-              useMesh={true}
-              animate={false}
-              crosshairType='cross'
-              tooltip={generateTooltip}
-              onClick={handleOnClick}
-              axisRight={{
-                tickSize: 5,
-                format: formatAxisY,
-              }}
-              axisLeft={{
-                tickSize: 5,
-                format: formatAxisY,
-              }}
-              axisBottom={{
-                tickSize: 5,
-                tickRotation: xType === 'base_amount' && width < 40 ? 45 : 0,
-                format: formatAxisX,
-              }}
-              margin={{ left: 65, right: 60, bottom: width < 40 ? 36 : 25, top: 10 }}
-              xFormat={(value) => Number(value).toFixed(0)}
-              lineWidth={3}
-              theme={getNivoScheme(theme)}
-              colors={[theme.palette.secondary.main, theme.palette.primary.main]}
-              xScale={{
-                type: 'linear',
-                min: center - xRange,
-                max: center + xRange,
-              }}
-              layers={['axes', 'areas', 'crosshair', 'lines', centerLine, 'slices', 'mesh']}
-            />
-          </Grid>
-        </Grid>
-      )}
+        )}
+      </Paper>
     </Paper>
   );
 };

--- a/frontend/src/components/Dialogs/UpdateClient.tsx
+++ b/frontend/src/components/Dialogs/UpdateClient.tsx
@@ -46,7 +46,7 @@ const UpdateClientDialog = ({
         <Typography>
           {t(
             'The RoboSats coordinator is on version {{coordinatorVersion}}, but your client app is {{clientVersion}}. This version mismatch might lead to a bad user experience.',
-            { coordinatorVersion: coordinatorVersion, clientVersion: clientVersion },
+            { coordinatorVersion, clientVersion },
           )}
         </Typography>
 
@@ -63,7 +63,7 @@ const UpdateClientDialog = ({
 
             <ListItemText
               secondary={t('Download RoboSats {{coordinatorVersion}} APK from Github releases', {
-                coordinatorVersion: coordinatorVersion,
+                coordinatorVersion,
               })}
               primary={t('On Android RoboSats app ')}
             />

--- a/frontend/src/components/HomePage.js
+++ b/frontend/src/components/HomePage.js
@@ -31,6 +31,23 @@ export default class HomePage extends Component {
     };
   }
 
+  componentDidMount = () => {
+    if (typeof window !== undefined) {
+      this.setState({ windowWidth: window.innerWidth, windowHeight: window.innerHeight });
+      window.addEventListener('resize', this.onResize);
+    }
+  };
+
+  componentWillUnmount = () => {
+    if (typeof window !== undefined) {
+      window.removeEventListener('resize', this.onResize);
+    }
+  };
+
+  onResize = () => {
+    this.setState({ windowWidth: window.innerWidth, windowHeight: window.innerHeight });
+  };
+
   setAppState = (newState) => {
     this.setState(newState);
   };
@@ -106,7 +123,7 @@ export default class HomePage extends Component {
         </div>
         <div
           className='bottomBar'
-          style={{ height: `${40 * fontSizeFactor}px`, width: window.innerWidth }}
+          style={{ height: `${40 * fontSizeFactor}px`, width: this.state.windowWidth }}
         >
           <BottomBar
             redirectTo={this.redirectTo}

--- a/frontend/src/components/OrderPage.js
+++ b/frontend/src/components/OrderPage.js
@@ -56,6 +56,7 @@ import { copyToClipboard } from '../utils/clipboard';
 import { getWebln } from '../utils/webln';
 import { apiClient } from '../services/api';
 import RobotAvatar from './Robots/RobotAvatar';
+import statusBadgeColor from '../utils/statusBadgeColor';
 
 class OrderPage extends Component {
   constructor(props) {
@@ -666,19 +667,6 @@ class OrderPage extends Component {
     return null;
   };
 
-  // Colors for the status badges
-  statusBadgeColor(status) {
-    if (status === 'Active') {
-      return 'success';
-    }
-    if (status === 'Seen recently') {
-      return 'warning';
-    }
-    if (status === 'Inactive') {
-      return 'error';
-    }
-  }
-
   orderBox = () => {
     const { t } = this.props;
     return (
@@ -694,7 +682,7 @@ class OrderPage extends Component {
               <ListItem>
                 <ListItemAvatar sx={{ width: 56, height: 56 }}>
                   <RobotAvatar
-                    statusColor={this.statusBadgeColor(this.state.maker_status)}
+                    statusColor={statusBadgeColor(this.state.maker_status)}
                     nickname={this.state.maker_nick}
                     tooltip={t(this.state.maker_status)}
                     orderType={this.state.type}
@@ -726,7 +714,7 @@ class OrderPage extends Component {
                         <ListItemAvatar>
                           <RobotAvatar
                             avatarClass='smallAvatar'
-                            statusColor={this.statusBadgeColor(this.state.taker_status)}
+                            statusColor={statusBadgeColor(this.state.taker_status)}
                             nickname={this.state.taker_nick}
                             tooltip={t(this.state.taker_status)}
                             orderType={this.state.type === 0 ? 1 : 0}

--- a/frontend/src/components/Robots/RobotAvatar/index.tsx
+++ b/frontend/src/components/Robots/RobotAvatar/index.tsx
@@ -4,7 +4,7 @@ import { Avatar, Badge, Tooltip } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { SendReceiveIcon } from '../../Icons';
 
-interface DepthChartProps {
+interface Props {
   nickname: string;
   smooth?: boolean;
   style?: object;
@@ -15,7 +15,7 @@ interface DepthChartProps {
   onLoad?: () => void;
 }
 
-const RobotAvatar: React.FC<DepthChartProps> = ({
+const RobotAvatar: React.FC<Props> = ({
   nickname,
   orderType,
   statusColor,

--- a/frontend/src/utils/checkVer.ts
+++ b/frontend/src/utils/checkVer.ts
@@ -15,8 +15,8 @@ export const checkVer: (
   const patchAvailable = !updateAvailable && patch > Number(semver[2]);
 
   return {
-    updateAvailable: updateAvailable,
-    patchAvailable: patchAvailable,
+    updateAvailable,
+    patchAvailable,
     coordinatorVersion: `v${major}.${minor}.${patch}`,
     clientVersion: `v${semver[0]}.${semver[1]}.${semver[2]}`,
   };

--- a/frontend/src/utils/hexToRgb.js
+++ b/frontend/src/utils/hexToRgb.js
@@ -1,0 +1,14 @@
+export default function hexToRgb(c) {
+  if (c.includes('rgb')) {
+    const vals = c.split('(')[1].split(')')[0];
+    return vals.split(',');
+  }
+  if (/^#([a-f0-9]{3}){1,2}$/.test(c)) {
+    if (c.length == 4) {
+      c = '#' + [c[1], c[1], c[2], c[2], c[3], c[3]].join('');
+    }
+    c = '0x' + c.substring(1);
+    return [(c >> 16) & 255, (c >> 8) & 255, c & 255];
+  }
+  return '';
+}

--- a/frontend/src/utils/statusBadgeColor.ts
+++ b/frontend/src/utils/statusBadgeColor.ts
@@ -1,0 +1,9 @@
+export default function statusBadgeColor(status: string) {
+  if (status === 'Active') {
+    return 'success';
+  }
+  if (status === 'Seen recently') {
+    return 'warning';
+  }
+  return 'error';
+}

--- a/frontend/static/css/index.css
+++ b/frontend/static/css/index.css
@@ -169,11 +169,12 @@ input[type='number'] {
   width: auto !important;
 }
 
-@media (max-width: 929px) {
+@media (max-height: 725px) {
   .appCenter:has(> div.MuiGrid-root:first-child, > div.MuiBox-root:first-child) {
-    overflow-y: scroll;
-    margin-top: 12px;
-    padding-bottom: 25px;
+    overflow-y: auto;
+    margin-top: 1em;
+    padding-bottom: 3em;
     height: 100%;
+    width: 100%;
   }
 }


### PR DESCRIPTION
## What does this PR do?
Turns the book table into a standalone component that is fully responsive.

Size of the book table will adapt to screen. The default number of rows will adapt to fit. The columns shown are ordered by importance and will be displayed according to the size of the display.

This feature is key if we want to reuse the book component in the new landing page and as a viewport in RoboSats Pro. It will also allow to fit the information better into any Android device.

### New columns behavior
The premium column is now colored following some basic logic. Outstanding premiums for buy offers are colored purple and bold, outstanding premiums for sell offers are colored blue and bold.

Expiry column: shows time left until expiration as a public order. It displays a circular determinate progress bar that becomes orange and red as time gets close to expiration. It displays the time left in the center in hours.

Timer column: displays `escrow_duration` time in hours and minutes.

Satoshis now: on large displays, the current size of the order in Satoshis is show. The value display is "thousands" of satioshis `${satoshis_now/1000}K`

Order id: on very large displays the Order ID is also shown.

### To test
Depth chart is also responsive to window resizes. Let's test by resizing the window and checking the two views ( depth and list) render correctly on every display. Special attention to be put into the columns the List view is displaying, some `width` resolution might display a combination of columns that is not as informative as it could be (e.g. on small windows, sometimes the Payment methods dissapear, yet these are very important).


## Checklist before merging
- [x] If its a frontend feature, I have ran prettier (`cd frontend; npm run format`).