### PR TITLE
Fix broken url in translations docs

### DIFF
--- a/docs/_pages/contribute/02-languages.md
+++ b/docs/_pages/contribute/02-languages.md
@@ -17,7 +17,7 @@ There isn't a lot of text in RoboSats, however it might be best to split the wor
 
 ### How to contribute a new translation.
 
-Simply create a new translation file in `frontend/src/locales` [Link to GitHub](https://github.com/Reckless-Satoshi/robosats/tree/main/frontend/src/locales). In `locales` there is a single file with a json dictionary for every language. In order to create a new translation, simply copy `en.json` (the master text) into a new file named after the language's [ISO 639 two character code](https://www.loc.gov/standards/iso639-2/php/English_list.php). 
+Simply create a new translation file in `frontend/src/static/locales` [Link to GitHub](https://github.com/Reckless-Satoshi/robosats/tree/main/frontend/static/locales). In `locales` there is a single file with a json dictionary for every language. In order to create a new translation, simply copy `en.json` (the master text) into a new file named after the language's [ISO 639 two character code](https://www.loc.gov/standards/iso639-2/php/English_list.php). 
 
 ### Guidelines
 


### PR DESCRIPTION
## What does this PR do?
Fix broken url in translations docs 
/frontend/locales => /frontend/static/locales
(I guess that the folder was moved at some point)

## Checklist before merging
- [X] If it's a frontend feature, I have ran prettier `cd frontend; npm run format`. If it's a mobile app feature I ran `cd mobile; npm run format`.