### PR TITLE
Add pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
           - merge-commit
         language: system
         files: ^frontend/
-        types: [javascript, jsx, ts, tsx, css, markdown, json] # uses https://github.com/pre-commit/identify
+        types_or: [javascript, jsx, ts, tsx, css, markdown, json] # uses https://github.com/pre-commit/identify
         entry: bash -c 'cd frontend && npm run format'
       - id: prettier-mobile
         name: prettier-mobile
@@ -36,7 +36,7 @@ repos:
           - merge-commit
         language: system
         files: ^mobile/
-        types: [javascript, jsx, ts, tsx, css, markdown, json] # uses https://github.com/pre-commit/identify
+        types_or: [javascript, jsx, ts, tsx, css, markdown, json] # uses https://github.com/pre-commit/identify
         entry: bash -c 'cd mobile && npm run format'
       - id: isort
         name: isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,64 @@
+# TODO
+# add a hook which automatically generates the OpenApi schema on API changes
+# and places them in an appropriate location
+repos:
+  - repo: 'https://github.com/pre-commit/pre-commit-hooks'
+    rev: v2.3.0
+    hooks:
+      - id: check-yaml
+      - id: check-toml
+      - id: mixed-line-ending
+        args:
+          - '--fix=lf'
+      - id: trailing-whitespace
+      - id: pretty-format-json
+        args:
+          - '--autofix'
+          - '--no-sort-keys'
+      - id: check-builtin-literals
+      - id: check-docstring-first
+      - id: check-merge-conflict
+  - repo: local
+    hooks:
+      - id: prettier-frontend
+        name: prettier-frontend
+        stages:
+          - commit
+          - merge-commit
+        language: system
+        files: ^frontend/
+        types: [javascript, jsx, ts, tsx, css, markdown, json] # uses https://github.com/pre-commit/identify
+        entry: bash -c 'cd frontend && npm run format'
+      - id: prettier-mobile
+        name: prettier-mobile
+        stages:
+          - commit
+          - merge-commit
+        language: system
+        files: ^mobile/
+        types: [javascript, jsx, ts, tsx, css, markdown, json] # uses https://github.com/pre-commit/identify
+        entry: bash -c 'cd mobile && npm run format'
+      - id: isort
+        name: isort
+        stages:
+          - commit
+          - merge-commit
+        language: system
+        types: [python]
+        entry: isort
+      - id: black
+        name: black
+        stages:
+          - commit
+          - merge-commit
+        language: system
+        types: [python]
+        entry: black
+      - id: flake8
+        name: flake8
+        stages:
+          - commit
+          - merge-commit
+        language: system
+        types: [python]
+        entry: flake8

--- a/api/logics.py
+++ b/api/logics.py
@@ -734,7 +734,11 @@ class Logics:
         if not order.taker_bond:
             return False, {"bad_request": "Wait for your order to be taken."}
         if (
-            not ( order.taker_bond.status == order.maker_bond.status == LNPayment.Status.LOCKED)
+            not (
+                order.taker_bond.status
+                == order.maker_bond.status
+                == LNPayment.Status.LOCKED
+            )
             and not order.status == Order.Status.FAI
         ):
             return False, {
@@ -753,7 +757,7 @@ class Logics:
         payout = LNNode.validate_ln_invoice(invoice, num_satoshis)
 
         if not payout["valid"]:
-            return False, payout['context']
+            return False, payout["context"]
 
         order.payout, _ = LNPayment.objects.update_or_create(
             concept=LNPayment.Concepts.PAYBUYER,
@@ -763,10 +767,10 @@ class Logics:
             receiver=user,
             # if there is a LNPayment matching these above, it updates that one with defaults below.
             defaults={
-                "invoice":invoice,
-                "status":LNPayment.Status.VALIDI,
-                "num_satoshis":num_satoshis,
-                "description": payout['description'],
+                "invoice": invoice,
+                "status": LNPayment.Status.VALIDI,
+                "num_satoshis": num_satoshis,
+                "description": payout["description"],
                 "payment_hash": payout["payment_hash"],
                 "created_at": payout["created_at"],
                 "expires_at": payout["expires_at"],

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -1,12 +1,11 @@
-from django.shortcuts import render
 from decouple import config
-
-# Create your views here.
+from django.shortcuts import render
 
 
 def basic(request, *args, **kwargs):
     context = {"ONION_LOCATION": config("ONION_LOCATION")}
     return render(request, "frontend/basic.html", context=context)
+
 
 def pro(request, *args, **kwargs):
     context = {"ONION_LOCATION": config("ONION_LOCATION")}


### PR DESCRIPTION
## What does this PR do?
Adds a [pre-commit](https://pre-commit.com/#install) config to run linters/formaters before committing 

Steps every contributor must follow before working:
1. make sure all the dependencies, include dev dependencies for python and node are installed
2. run `pip install pre-commit`
3. run `pre-commit install`
4. write awesome features, stage and commit your changes. The linters and formatters will run according to what you touch. If it's just a lint error (flake8) then fix it and stage the changes again and commit it.

## Checklist before merging
- [x] If it's a frontend feature, I have ran prettier `cd frontend; npm run format`. If it's a mobile app feature I ran `cd mobile; npm run format`.