### PR TITLE
Do not convert non-ascii to unicode escape sequences in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
         args:
           - '--autofix'
           - '--no-sort-keys'
+          - '--no-ensure-ascii'
       - id: check-builtin-literals
       - id: check-docstring-first
       - id: check-merge-conflict


### PR DESCRIPTION
## What does this PR do?
Adds a arg to let pretty-format-json not convert non-ascii chars to unicode escape sequences 

## Checklist before merging
- [x] Make sure you have installed and initialized [pre-commit](https://pre-commit.com). `pip install pre-commit` and `pre-commit install`
