### PR TITLE
Fix export chat android

### DIFF
--- a/frontend/src/components/TradeBox/EncryptedChat/ChatBottom/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/ChatBottom/index.tsx
@@ -19,12 +19,11 @@ const ChatBottom: React.FC<Props> = ({ orderId, setAudit, audit, createJsonFile 
 
   const onPGPClick: () => void = () => {
     if (window.ReactNativeWebView === undefined) {
-      saveAsJson('complete_log_chat_' + orderId + '.json', createJsonFile())
+      saveAsJson('complete_log_chat_' + orderId + '.json', createJsonFile());
     } else {
-      systemClient.copyToClipboard(JSON.stringify(createJsonFile()))
+      systemClient.copyToClipboard(JSON.stringify(createJsonFile()));
     }
-    
-  }
+  };
 
   return (
     <>
@@ -51,12 +50,7 @@ const ChatBottom: React.FC<Props> = ({ orderId, setAudit, audit, createJsonFile 
           enterNextDelay={2000}
           title={t('Save full log as a JSON file (messages and credentials)')}
         >
-          <Button
-            size='small'
-            color='primary'
-            variant='outlined'
-            onClick={onPGPClick}
-          >
+          <Button size='small' color='primary' variant='outlined' onClick={onPGPClick}>
             <div style={{ width: '1.4em', height: '1.4em' }}>
               <ExportIcon sx={{ width: '0.8em', height: '0.8em' }} />
             </div>{' '}

--- a/frontend/src/components/TradeBox/EncryptedChat/ChatBottom/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/ChatBottom/index.tsx
@@ -4,6 +4,7 @@ import { ExportIcon } from '../../../Icons';
 import KeyIcon from '@mui/icons-material/Key';
 import { useTranslation } from 'react-i18next';
 import { saveAsJson } from '../../../../utils';
+import { systemClient } from '../../../../services/System';
 
 interface Props {
   orderId: number;
@@ -15,6 +16,15 @@ interface Props {
 const ChatBottom: React.FC<Props> = ({ orderId, setAudit, audit, createJsonFile }) => {
   const { t } = useTranslation();
   const theme = useTheme();
+
+  const onPGPClick: () => void = () => {
+    if (window.ReactNativeWebView === undefined) {
+      saveAsJson('complete_log_chat_' + orderId + '.json', createJsonFile())
+    } else {
+      systemClient.copyToClipboard(JSON.stringify(createJsonFile()))
+    }
+    
+  }
 
   return (
     <>
@@ -45,7 +55,7 @@ const ChatBottom: React.FC<Props> = ({ orderId, setAudit, audit, createJsonFile 
             size='small'
             color='primary'
             variant='outlined'
-            onClick={() => saveAsJson('complete_log_chat_' + orderId + '.json', createJsonFile())}
+            onClick={onPGPClick}
           >
             <div style={{ width: '1.4em', height: '1.4em' }}>
               <ExportIcon sx={{ width: '0.8em', height: '0.8em' }} />


### PR DESCRIPTION
## What does this PR do?
Fixes the Export chat button, when clicked on Android, it copies the content to the clipboard instead of generating a file.

## Checklist before merging
- [x] Make sure you have installed and initialized [pre-commit](https://pre-commit.com). `pip install pre-commit` and `pre-commit install`
