### PR TITLE
Add advanced options to LN payout form

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -127,7 +127,7 @@ class LNPayment(models.Model):
         ]
     )
     # Routing budget in PPM
-    routing_budget = models.PositiveBigIntegerField(
+    routing_budget_ppm = models.PositiveBigIntegerField(
         default=0,
         null=False,
         validators=[

--- a/api/models.py
+++ b/api/models.py
@@ -126,6 +126,19 @@ class LNPayment(models.Model):
             MaxValueValidator(1.5 * MAX_TRADE),
         ]
     )
+    # Routing budget in PPM
+    routing_budget = models.PositiveBigIntegerField(
+        default=0,
+        null=False,
+        validators=[
+            MinValueValidator(0),
+            MaxValueValidator(100000),
+        ],
+    )
+    # Routing budget in Sats. Only for reporting summaries.
+    routing_budget_sats = models.DecimalField(
+        max_digits=10, decimal_places=3, default=0, null=False, blank=False
+    )
     # Fee in sats with mSats decimals fee_msat
     fee = models.DecimalField(
         max_digits=10, decimal_places=3, default=0, null=False, blank=False

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -489,6 +489,14 @@ class UpdateOrderSerializer(serializers.Serializer):
     invoice = serializers.CharField(
         max_length=2000, allow_null=True, allow_blank=True, default=None
     )
+    routing_budget_ppm = serializers.IntegerField(
+        default=0,
+        min_value=0,
+        max_value=100000,
+        allow_null=True,
+        required=False,
+        help_text="Max budget to allocate for routing in PPM",
+    )
     address = serializers.CharField(
         max_length=100, allow_null=True, allow_blank=True, default=None
     )

--- a/api/views.py
+++ b/api/views.py
@@ -501,6 +501,7 @@ class OrderView(viewsets.ViewSet):
         # 5.b)'update_address' 6)'submit_statement' (in dispute), 7)'rate_user' , 8)'rate_platform'
         action = serializer.data.get("action")
         invoice = serializer.data.get("invoice")
+        routing_budget_ppm = serializer.data.get("routing_budget_ppm", 0)
         address = serializer.data.get("address")
         mining_fee_rate = serializer.data.get("mining_fee_rate")
         statement = serializer.data.get("statement")
@@ -543,7 +544,9 @@ class OrderView(viewsets.ViewSet):
 
         # 2) If action is 'update invoice'
         elif action == "update_invoice":
-            valid, context = Logics.update_invoice(order, request.user, invoice)
+            valid, context = Logics.update_invoice(
+                order, request.user, invoice, routing_budget_ppm
+            )
             if not valid:
                 return Response(context, status.HTTP_400_BAD_REQUEST)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     environment:
       TOR_PROXY_IP: 127.0.0.1
       TOR_PROXY_PORT: 9050
-      ROBOSATS_ONION: robotestagw3dcxmd66r4rgksb4nmmr43fh77bzn2ia2eucduyeafnyd.onion
+      ROBOSATS_ONION: robosats6tkf3eva7x2voqso3a5wcorsnw34jveyxfqi2fu7oyheasid.onion
     network_mode: service:tor
     volumes:
       - ./frontend/static:/usr/src/robosats/static

--- a/frontend/src/basic/Main.tsx
+++ b/frontend/src/basic/Main.tsx
@@ -181,7 +181,7 @@ const Main = ({ settings, setSettings }: MainProps): JSX.Element => {
     return await data;
   };
 
-  const fetchInfo = function () {
+  const fetchInfo = function (setNetwork?: boolean) {
     setInfo({ ...info, loading: true });
     apiClient.get(baseUrl, '/api/info/').then((data: Info) => {
       const versionInfo: any = checkVer(data.version.major, data.version.minor, data.version.patch);
@@ -192,12 +192,16 @@ const Main = ({ settings, setSettings }: MainProps): JSX.Element => {
         clientVersion: versionInfo.clientVersion,
         loading: false,
       });
+      // Sets Setting network from coordinator API param if accessing via web
+      if (setNetwork) {
+        setSettings({ ...settings, network: data.network });
+      }
     });
   };
 
   useEffect(() => {
     if (open.stats || open.coordinator || info.coordinatorVersion == 'v?.?.?') {
-      fetchInfo();
+      fetchInfo(info.coordinatorVersion == 'v?.?.?');
     }
   }, [open.stats, open.coordinator]);
 
@@ -424,6 +428,7 @@ const Main = ({ settings, setSettings }: MainProps): JSX.Element => {
                   <OrderPage
                     baseUrl={baseUrl}
                     order={order}
+                    settings={settings}
                     setOrder={setOrder}
                     setCurrentOrder={setCurrentOrder}
                     badOrder={badOrder}

--- a/frontend/src/basic/OrderPage/index.tsx
+++ b/frontend/src/basic/OrderPage/index.tsx
@@ -7,12 +7,13 @@ import TradeBox from '../../components/TradeBox';
 import OrderDetails from '../../components/OrderDetails';
 
 import { Page } from '../NavBar';
-import { Order } from '../../models';
+import { Order, Settings } from '../../models';
 import { apiClient } from '../../services/api';
 
 interface OrderPageProps {
   windowSize: { width: number; height: number };
   order: Order;
+  settings: Settings;
   setOrder: (state: Order) => void;
   setCurrentOrder: (state: number) => void;
   fetchOrder: () => void;
@@ -27,6 +28,7 @@ interface OrderPageProps {
 const OrderPage = ({
   windowSize,
   order,
+  settings,
   setOrder,
   setCurrentOrder,
   badOrder,
@@ -128,6 +130,7 @@ const OrderPage = ({
                 >
                   <TradeBox
                     order={order}
+                    settings={settings}
                     setOrder={setOrder}
                     setBadOrder={setBadOrder}
                     baseUrl={baseUrl}

--- a/frontend/src/basic/OrderPage/index.tsx
+++ b/frontend/src/basic/OrderPage/index.tsx
@@ -173,6 +173,7 @@ const OrderPage = ({
                 <div style={{ display: tab == 'contract' ? '' : 'none' }}>
                   <TradeBox
                     order={order}
+                    settings={settings}
                     setOrder={setOrder}
                     setBadOrder={setBadOrder}
                     baseUrl={baseUrl}

--- a/frontend/src/components/Notifications/index.tsx
+++ b/frontend/src/components/Notifications/index.tsx
@@ -134,7 +134,7 @@ const Notifications = ({
       title: t('Order has expired'),
       severity: 'warning',
       onClick: moveToOrderPage,
-      sound: undefined,
+      sound: audio.ding,
       timeout: 30000,
       pageTitle: `${t('😪 Expired!')} - ${basePageTitle}`,
     },

--- a/frontend/src/components/Notifications/index.tsx
+++ b/frontend/src/components/Notifications/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { StringIfPlural, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import {
   Tooltip,
   Alert,
@@ -262,7 +262,6 @@ const Notifications = ({
     } else if (order?.is_seller && status > 7 && oldStatus < 7) {
       message = Messages.escrowLocked;
     } else if ([9, 10].includes(status) && oldStatus < 9) {
-      console.log('yoooo');
       message = Messages.chat;
     } else if (order?.is_seller && [13, 14, 15].includes(status) && oldStatus < 13) {
       message = Messages.successful;
@@ -333,7 +332,6 @@ const Notifications = ({
   return (
     <StyledTooltip
       open={show}
-      style={{ padding: 0, backgroundColor: 'black' }}
       placement={windowWidth > 60 ? 'left' : 'bottom'}
       title={
         <Alert

--- a/frontend/src/components/OrderDetails/LinearDeterminate.tsx
+++ b/frontend/src/components/OrderDetails/LinearDeterminate.tsx
@@ -29,7 +29,7 @@ const LinearDeterminate = ({ expiresAt, totalSecsExp }: Props): JSX.Element => {
         sx={{ height: '0.4em' }}
         variant='determinate'
         value={progress}
-        color={progress < 20 ? 'secondary' : 'primary'}
+        color={progress < 25 ? 'secondary' : 'primary'}
       />
     </Box>
   );

--- a/frontend/src/components/OrderDetails/index.tsx
+++ b/frontend/src/components/OrderDetails/index.tsx
@@ -12,6 +12,7 @@ import {
   Grid,
   Collapse,
   useTheme,
+  Typography,
 } from '@mui/material';
 
 import Countdown, { CountdownRenderProps, zeroPad } from 'react-countdown';
@@ -86,25 +87,25 @@ const OrderDetails = ({
       // Render a completed state
       return <span> {t('The order has expired')}</span>;
     } else {
-      let col = 'inherit';
+      let color = 'inherit';
       const fraction_left = total / 1000 / order.total_secs_exp;
       // Make orange at 25% of time left
       if (fraction_left < 0.25) {
-        col = 'orange';
+        color = theme.palette.warning.main;
       }
       // Make red at 10% of time left
       if (fraction_left < 0.1) {
-        col = 'red';
+        color = theme.palette.error.main;
       }
       // Render a countdown, bold when less than 25%
       return fraction_left < 0.25 ? (
-        <b>
-          <span style={{ color: col }}>
-            {`${hours}h ${zeroPad(minutes)}m ${zeroPad(seconds)}s `}
-          </span>
-        </b>
+        <Typography color={color}>
+          <b>{`${hours}h ${zeroPad(minutes)}m ${zeroPad(seconds)}s `}</b>
+        </Typography>
       ) : (
-        <span style={{ color: col }}>{`${hours}h ${zeroPad(minutes)}m ${zeroPad(seconds)}s `}</span>
+        <Typography color={color}>
+          {`${hours}h ${zeroPad(minutes)}m ${zeroPad(seconds)}s `}
+        </Typography>
       );
     }
   };

--- a/frontend/src/components/TradeBox/EncryptedChat/ChatHeader/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/ChatHeader/index.tsx
@@ -77,7 +77,7 @@ const ChatHeader: React.FC<Props> = ({ connected, peerConnected, turtleMode, set
         >
           <Typography align='center' variant='caption' sx={{ color: connectedTextColor }}>
             {t('Peer') + ': '}
-            {peerConnected ? t('connected') : t('disconnected')}
+            {connected ? (peerConnected ? t('connected') : t('disconnected')) : '...waiting'}
           </Typography>
         </Paper>
       </Grid>

--- a/frontend/src/components/TradeBox/EncryptedChat/EncryptedSocketChat/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/EncryptedSocketChat/index.tsx
@@ -72,6 +72,7 @@ const EncryptedSocketChat: React.FC<Props> = ({
   useEffect(() => {
     if (![9, 10].includes(status)) {
       connection?.close();
+      setConnection(undefined);
     }
   }, [status]);
 

--- a/frontend/src/components/TradeBox/Forms/LightningPayout.tsx
+++ b/frontend/src/components/TradeBox/Forms/LightningPayout.tsx
@@ -1,28 +1,60 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Grid, Typography, TextField } from '@mui/material';
+import {
+  Box,
+  Grid,
+  Typography,
+  TextField,
+  Tooltip,
+  FormControlLabel,
+  Checkbox,
+  useTheme,
+  Collapse,
+  Switch,
+} from '@mui/material';
 import { Order } from '../../../models';
 import WalletsButton from '../WalletsButton';
 import { LoadingButton } from '@mui/lab';
 import { pn } from '../../../utils';
 
+import { RoundaboutRight, Route, SelfImprovement } from '@mui/icons-material';
+import { apiClient } from '../../../services/api';
+
+import lnproxies from '../../../../static/lnproxies.json';
+
 export interface LightningForm {
   invoice: string;
-  routingBudget: number;
+  amount: number;
+  advancedOptions: boolean;
+  useCustomBudget: boolean;
+  routingBudgetUnit: 'PPM' | 'Sats';
+  routingBudgetPPM: number;
+  routingBudgetSats: number;
   badInvoice: string;
   useLnproxy: boolean;
-  lnproxyServer: string;
-  lnproxyBudget: number;
+  lnproxyInvoice: string;
+  lnproxyServer: number;
+  lnproxyBudgetUnit: 'PPM' | 'Sats';
+  lnproxyBudgetPPM: number;
+  lnproxyBudgetSats: number;
   badLnproxy: string;
 }
 
 export const defaultLightning: LightningForm = {
   invoice: '',
-  routingBudget: 0,
+  amount: 0,
+  advancedOptions: false,
+  useCustomBudget: false,
+  routingBudgetUnit: 'PPM',
+  routingBudgetPPM: 1000,
+  routingBudgetSats: 0,
   badInvoice: '',
   useLnproxy: false,
-  lnproxyServer: '',
-  lnproxyBudget: 0,
+  lnproxyInvoice: '',
+  lnproxyServer: 0,
+  lnproxyBudgetUnit: 'PPM',
+  lnproxyBudgetPPM: 0,
+  lnproxyBudgetSats: 0,
   badLnproxy: '',
 };
 
@@ -42,46 +74,221 @@ export const LightningPayoutForm = ({
   setLightning,
 }: LightningPayoutFormProps): JSX.Element => {
   const { t } = useTranslation();
+  const theme = useTheme();
+
+  const computeInvoiceAmount = function () {
+    return (
+      order.trade_satoshis -
+      Math.round((order.trade_satoshis / 1000000) * lightning.routingBudgetPPM)
+    );
+  };
+
+  useEffect(() => {
+    setLightning({
+      ...lightning,
+      amount: computeInvoiceAmount(),
+    });
+  }, []);
+
+  const fetchLnproxy = function () {
+    apiClient
+      .get(
+        `http://${lnproxies[lightning.lnproxyServer].mainnetOnion}`,
+        `/api/${lightning.lnproxyInvoice}?routing_msat=${lightning.lnproxyBudgetSats * 1000}`,
+      )
+      .then((data) => {
+        setLightning({ ...lightning, invoice: String(data) });
+      })
+      .catch(() => {
+        setLightning({ ...lightning, badLnproxy: 'Lnproxy error' });
+      });
+  };
+
   return (
     <Grid container direction='column' justifyContent='flex-start' alignItems='center' spacing={1}>
-      <Grid item xs={12}>
+      <Grid item>
         <Typography variant='body2'>
           {t('Submit a valid invoice for {{amountSats}} Satoshis.', {
-            amountSats: pn(order.invoice_amount),
+            amountSats: pn(lightning.amount),
           })}
         </Typography>
       </Grid>
 
-      <Grid item xs={12}>
+      <Grid item>
         <WalletsButton />
       </Grid>
 
-      <Grid item xs={12}>
-        <TextField
-          fullWidth={true}
-          error={lightning.badInvoice != ''}
-          helperText={lightning.badInvoice ? t(lightning.badInvoice) : ''}
-          label={t('Payout Lightning Invoice')}
-          required
-          value={lightning.invoice}
-          inputProps={{
-            style: { textAlign: 'center', maxHeight: '14.28em' },
+      <Grid
+        item
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          height: '1.1em',
+        }}
+      >
+        {' '}
+        <Typography color='text.secondary'>{t('Advanced options')}</Typography>
+        <Switch
+          size='small'
+          checked={lightning.advancedOptions}
+          onChange={(e) => {
+            const checked = e.target.checked;
+            setLightning({
+              ...lightning,
+              advancedOptions: checked,
+              useLnproxy: checked ? lightning.useLnproxy : false,
+              useCustomBudget: checked ? lightning.useCustomBudget : false,
+            });
           }}
-          multiline
-          minRows={4}
-          maxRows={8}
-          onChange={(e) => setLightning({ ...lightning, invoice: e.target.value ?? '' })}
         />
+        <SelfImprovement sx={{ color: 'text.secondary' }} />
       </Grid>
-      <Grid item xs={12}>
-        <LoadingButton
-          loading={loading}
-          onClick={() => onClickSubmit(lightning.invoice)}
-          variant='outlined'
-          color='primary'
+
+      <Grid item>
+        <Collapse in={lightning.advancedOptions}>
+          <Box
+            sx={{
+              backgroundColor: 'background.paper',
+              border: '1px solid',
+              width: '18em',
+              borderRadius: '4px',
+              borderColor: theme.palette.mode === 'dark' ? '#434343' : '#c4c4c4',
+              '&:hover': {
+                borderColor: theme.palette.mode === 'dark' ? '#ffffff' : '#2f2f2f',
+              },
+            }}
+          >
+            <Grid
+              container
+              direction='column'
+              justifyContent='flex-start'
+              alignItems='center'
+              spacing={0.5}
+              padding={0.5}
+            >
+              <Grid item>
+                <Tooltip
+                  enterTouchDelay={0}
+                  leaveTouchDelay={4000}
+                  placement='top'
+                  title={t(
+                    `Wrap this invoice using a Lnproxy service to protect privacy (hides receiving wallet).`,
+                  )}
+                >
+                  <FormControlLabel
+                    onChange={(e) =>
+                      setLightning({
+                        ...lightning,
+                        useLnproxy: e.target.checked,
+                        invoice: e.target.checked ? '' : lightning.invoice,
+                      })
+                    }
+                    checked={lightning.useLnproxy}
+                    control={<Checkbox />}
+                    label={
+                      <Typography color={lightning.useLnproxy ? 'primary' : 'text.secondary'}>
+                        {t('Use Lnproxy')}
+                      </Typography>
+                    }
+                  />
+                </Tooltip>
+              </Grid>
+              <Collapse in={lightning.useLnproxy}>
+                <Grid item>
+                  <LoadingButton
+                    loading={loading}
+                    onClick={fetchLnproxy}
+                    variant='outlined'
+                    color='primary'
+                  >
+                    {t('Submit')}
+                  </LoadingButton>
+                </Grid>
+              </Collapse>
+            </Grid>
+          </Box>
+        </Collapse>
+      </Grid>
+
+      <Grid item>
+        <Box
+          sx={{
+            backgroundColor: 'background.paper',
+            border: '1px solid',
+            borderRadius: '4px',
+            width: '18em',
+            borderColor: theme.palette.mode === 'dark' ? '#434343' : '#c4c4c4',
+            '&:hover': {
+              borderColor: theme.palette.mode === 'dark' ? '#ffffff' : '#2f2f2f',
+            },
+          }}
         >
-          {t('Submit')}
-        </LoadingButton>
+          <Grid
+            container
+            direction='column'
+            justifyContent='flex-start'
+            alignItems='center'
+            spacing={0.5}
+            padding={0.5}
+          >
+            <Collapse in={lightning.advancedOptions}>
+              <Tooltip
+                enterTouchDelay={0}
+                leaveTouchDelay={4000}
+                placement='top'
+                title={t(
+                  `Set custom routing budget for the payout. If you don't know what this is, simply do not touch.`,
+                )}
+              >
+                <FormControlLabel
+                  checked={lightning.useCustomBudget}
+                  onChange={(e) =>
+                    setLightning({ ...lightning, useCustomBudget: e.target.checked })
+                  }
+                  control={<Checkbox />}
+                  label={
+                    <Typography
+                      style={{ display: 'flex', alignItems: 'center' }}
+                      color={lightning.useCustomBudget ? 'primary' : 'text.secondary'}
+                    >
+                      {t('Use custom routing budget')}
+                    </Typography>
+                  }
+                />
+              </Tooltip>
+            </Collapse>
+
+            <Grid item>
+              <TextField
+                fullWidth={true}
+                disabled={lightning.useLnproxy}
+                error={lightning.badInvoice != ''}
+                helperText={lightning.badInvoice ? t(lightning.badInvoice) : ''}
+                label={t('Payout Lightning Invoice')}
+                required
+                value={lightning.invoice}
+                inputProps={{
+                  style: { textAlign: 'center', maxHeight: '6em' },
+                }}
+                variant='standard'
+                multiline
+                minRows={2}
+                maxRows={4}
+                onChange={(e) => setLightning({ ...lightning, invoice: e.target.value ?? '' })}
+              />
+            </Grid>
+            <Grid item>
+              <LoadingButton
+                loading={loading}
+                onClick={() => onClickSubmit(lightning.invoice)}
+                variant='outlined'
+                color='primary'
+              >
+                {t('Submit')}
+              </LoadingButton>
+            </Grid>
+          </Grid>
+        </Box>
       </Grid>
     </Grid>
   );

--- a/frontend/src/components/TradeBox/Forms/LightningPayout.tsx
+++ b/frontend/src/components/TradeBox/Forms/LightningPayout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Box,
@@ -11,6 +11,12 @@ import {
   useTheme,
   Collapse,
   Switch,
+  MenuItem,
+  Select,
+  InputAdornment,
+  Button,
+  FormControl,
+  InputLabel,
 } from '@mui/material';
 import { Order } from '../../../models';
 import WalletsButton from '../WalletsButton';
@@ -29,10 +35,11 @@ export interface LightningForm {
   useCustomBudget: boolean;
   routingBudgetUnit: 'PPM' | 'Sats';
   routingBudgetPPM: number;
-  routingBudgetSats: number;
+  routingBudgetSats: number | undefined;
   badInvoice: string;
   useLnproxy: boolean;
   lnproxyInvoice: string;
+  lnproxyAmount: number;
   lnproxyServer: number;
   lnproxyBudgetUnit: 'PPM' | 'Sats';
   lnproxyBudgetPPM: number;
@@ -47,12 +54,13 @@ export const defaultLightning: LightningForm = {
   useCustomBudget: false,
   routingBudgetUnit: 'PPM',
   routingBudgetPPM: 1000,
-  routingBudgetSats: 0,
+  routingBudgetSats: undefined,
   badInvoice: '',
   useLnproxy: false,
   lnproxyInvoice: '',
+  lnproxyAmount: 0,
   lnproxyServer: 0,
-  lnproxyBudgetUnit: 'PPM',
+  lnproxyBudgetUnit: 'Sats',
   lnproxyBudgetPPM: 0,
   lnproxyBudgetSats: 0,
   badLnproxy: '',
@@ -76,48 +84,109 @@ export const LightningPayoutForm = ({
   const { t } = useTranslation();
   const theme = useTheme();
 
+  const [loadingLnproxy, setLoadingLnproxy] = useState<boolean>(false);
+
   const computeInvoiceAmount = function () {
-    return (
-      order.trade_satoshis -
-      Math.round((order.trade_satoshis / 1000000) * lightning.routingBudgetPPM)
-    );
+    //const tradeAmount = order.trade_satoshis
+    const tradeAmount = 10000;
+    return tradeAmount - Math.round((tradeAmount / 1000000) * lightning.routingBudgetPPM);
   };
 
   useEffect(() => {
+    const amount = computeInvoiceAmount();
     setLightning({
       ...lightning,
-      amount: computeInvoiceAmount(),
+      amount,
+      lnproxyAmount: amount - lightning.lnproxyBudgetSats,
+      routingBudgetSats:
+        lightning.routingBudgetSats == undefined
+          ? (amount / 1000000) * lightning.routingBudgetPPM
+          : lightning.routingBudgetSats,
     });
-  }, []);
+  }, [lightning.routingBudgetPPM]);
+
+  const lnproxyUrl = function () {
+    return `http://${lnproxies[lightning.lnproxyServer].mainnetOnion}`;
+  };
 
   const fetchLnproxy = function () {
+    setLoadingLnproxy(true);
     apiClient
       .get(
-        `http://${lnproxies[lightning.lnproxyServer].mainnetOnion}`,
+        lnproxyUrl(),
         `/api/${lightning.lnproxyInvoice}?routing_msat=${lightning.lnproxyBudgetSats * 1000}`,
       )
       .then((data) => {
-        setLightning({ ...lightning, invoice: String(data) });
+        const response = String(data);
+        if (response.includes('lnproxy error')) {
+          setLightning({ ...lightning, badLnproxy: response });
+        } else {
+          setLightning({ ...lightning, invoice: String(data), badLnproxy: '' });
+        }
       })
-      .catch(() => {
-        setLightning({ ...lightning, badLnproxy: 'Lnproxy error' });
+      // .catch(() => {
+      //   setLightning({ ...lightning, badLnproxy: 'Lnproxy server uncaught error' });
+      // })
+      .finally(() => {
+        setLoadingLnproxy(false);
       });
+  };
+
+  const onProxyBudgetChange = function (e) {
+    if (isFinite(e.target.value)) {
+      if (lightning.lnproxyBudgetUnit === 'Sats') {
+        const lnproxyBudgetSats = Math.floor(e.target.value);
+        const lnproxyBudgetPPM = Math.round((lnproxyBudgetSats * 1000000) / lightning.amount);
+        const lnproxyAmount = lightning.amount - lnproxyBudgetSats;
+        setLightning({ ...lightning, lnproxyBudgetSats, lnproxyBudgetPPM, lnproxyAmount });
+      } else {
+        const lnproxyBudgetPPM = e.target.value;
+        const lnproxyBudgetSats = Math.round((lightning.amount / 1000000) * lnproxyBudgetPPM);
+        const lnproxyAmount = lightning.amount - lnproxyBudgetSats;
+        setLightning({ ...lightning, lnproxyBudgetSats, lnproxyBudgetPPM, lnproxyAmount });
+      }
+    }
+  };
+
+  const onRoutingBudgetChange = function (e) {
+    if (isFinite(e.target.value)) {
+      if (lightning.routingBudgetUnit === 'Sats') {
+        const routingBudgetSats = Math.floor(e.target.value);
+        const routingBudgetPPM = Math.round((routingBudgetSats * 1000000) / lightning.amount);
+        const amount = lightning.amount - routingBudgetSats;
+        setLightning({ ...lightning, routingBudgetSats, routingBudgetPPM, amount });
+      } else {
+        const routingBudgetPPM = e.target.value;
+        const routingBudgetSats = Math.round((lightning.amount / 1000000) * routingBudgetPPM);
+        const amount = lightning.amount - routingBudgetSats;
+        setLightning({ ...lightning, routingBudgetSats, routingBudgetPPM, amount });
+      }
+    }
+  };
+
+  const lnProxyBudgetHelper = function () {
+    let text = '';
+    if (lightning.lnproxyBudgetSats < 0) {
+      text = 'Must be positive';
+    } else if (lightning.lnproxyBudgetPPM > 10000) {
+      text = 'Too high! (That is more than 1%)';
+    }
+    return text;
+  };
+
+  const routingBudgetHelper = function () {
+    let text = '';
+    if (lightning.routingBudgetSats < 0) {
+      text = 'Must be positive';
+    } else if (lightning.routingBudgetPPM > 10000) {
+      text = 'Too high! (That is more than 1%)';
+    }
+    return text;
   };
 
   return (
     <Grid container direction='column' justifyContent='flex-start' alignItems='center' spacing={1}>
-      <Grid item>
-        <Typography variant='body2'>
-          {t('Submit a valid invoice for {{amountSats}} Satoshis.', {
-            amountSats: pn(lightning.amount),
-          })}
-        </Typography>
-      </Grid>
-
-      <Grid item>
-        <WalletsButton />
-      </Grid>
-
+      <div style={{ height: '0.3em' }} />
       <Grid
         item
         style={{
@@ -126,8 +195,7 @@ export const LightningPayoutForm = ({
           height: '1.1em',
         }}
       >
-        {' '}
-        <Typography color='text.secondary'>{t('Advanced options')}</Typography>
+        <Typography color='text.primary'>{t('Advanced options')}</Typography>
         <Switch
           size='small'
           checked={lightning.advancedOptions}
@@ -137,76 +205,176 @@ export const LightningPayoutForm = ({
               ...lightning,
               advancedOptions: checked,
               useLnproxy: checked ? lightning.useLnproxy : false,
+              invoice: checked ? '' : lightning.invoice,
               useCustomBudget: checked ? lightning.useCustomBudget : false,
             });
           }}
         />
-        <SelfImprovement sx={{ color: 'text.secondary' }} />
+        <SelfImprovement sx={{ color: 'text.primary' }} />
       </Grid>
 
       <Grid item>
         <Collapse in={lightning.advancedOptions}>
-          <Box
-            sx={{
-              backgroundColor: 'background.paper',
-              border: '1px solid',
-              width: '18em',
-              borderRadius: '4px',
-              borderColor: theme.palette.mode === 'dark' ? '#434343' : '#c4c4c4',
-              '&:hover': {
-                borderColor: theme.palette.mode === 'dark' ? '#ffffff' : '#2f2f2f',
-              },
-            }}
+          <Tooltip
+            enterTouchDelay={0}
+            leaveTouchDelay={4000}
+            placement='top'
+            title={t(
+              `Wrap this invoice using a Lnproxy server to protect your privacy (hides the receiving wallet).`,
+            )}
           >
-            <Grid
-              container
-              direction='column'
-              justifyContent='flex-start'
-              alignItems='center'
-              spacing={0.5}
-              padding={0.5}
+            <Box
+              sx={{
+                backgroundColor: 'background.paper',
+                border: '1px solid',
+                width: '18em',
+                borderRadius: '0.3em',
+                borderColor: theme.palette.mode === 'dark' ? '#434343' : '#c4c4c4',
+                '&:hover': {
+                  borderColor: theme.palette.mode === 'dark' ? '#ffffff' : '#2f2f2f',
+                },
+              }}
             >
-              <Grid item>
-                <Tooltip
-                  enterTouchDelay={0}
-                  leaveTouchDelay={4000}
-                  placement='top'
-                  title={t(
-                    `Wrap this invoice using a Lnproxy service to protect privacy (hides receiving wallet).`,
-                  )}
-                >
-                  <FormControlLabel
-                    onChange={(e) =>
-                      setLightning({
-                        ...lightning,
-                        useLnproxy: e.target.checked,
-                        invoice: e.target.checked ? '' : lightning.invoice,
-                      })
-                    }
-                    checked={lightning.useLnproxy}
-                    control={<Checkbox />}
-                    label={
-                      <Typography color={lightning.useLnproxy ? 'primary' : 'text.secondary'}>
-                        {t('Use Lnproxy')}
-                      </Typography>
-                    }
-                  />
-                </Tooltip>
-              </Grid>
-              <Collapse in={lightning.useLnproxy}>
+              <Grid
+                container
+                direction='column'
+                justifyContent='flex-start'
+                alignItems='center'
+                spacing={0.5}
+                padding={0.5}
+              >
                 <Grid item>
-                  <LoadingButton
-                    loading={loading}
-                    onClick={fetchLnproxy}
-                    variant='outlined'
-                    color='primary'
-                  >
-                    {t('Submit')}
-                  </LoadingButton>
+                  <div>
+                    <FormControlLabel
+                      onChange={(e) =>
+                        setLightning({
+                          ...lightning,
+                          useLnproxy: e.target.checked,
+                          invoice: e.target.checked ? '' : lightning.invoice,
+                        })
+                      }
+                      checked={lightning.useLnproxy}
+                      control={<Checkbox />}
+                      label={
+                        <Typography color={lightning.useLnproxy ? 'primary' : 'text.secondary'}>
+                          {t('Use Lnproxy')}
+                        </Typography>
+                      }
+                    />
+                  </div>
                 </Grid>
-              </Collapse>
-            </Grid>
-          </Box>
+                <Grid item>
+                  <Collapse in={lightning.useLnproxy}>
+                    <Grid
+                      container
+                      direction='column'
+                      justifyContent='flex-start'
+                      alignItems='center'
+                      spacing={1}
+                    >
+                      <Grid item>
+                        <FormControl>
+                          <InputLabel id='select-label'>{t('Server')}</InputLabel>
+                          <Select
+                            sx={{ width: '14em' }}
+                            label={t('Server')}
+                            labelId='select-label'
+                            value={lightning.lnproxyServer}
+                            onChange={(e) =>
+                              setLightning({ ...lightning, lnproxyServer: Number(e.target.value) })
+                            }
+                          >
+                            {lnproxies.map((lnproxyServer, index) => (
+                              <MenuItem key={index} value={index}>
+                                <Typography>{lnproxyServer.name}</Typography>
+                              </MenuItem>
+                            ))}
+                          </Select>
+                        </FormControl>
+                      </Grid>
+
+                      <Grid item>
+                        <TextField
+                          sx={{ width: '14em' }}
+                          disabled={!lightning.useLnproxy}
+                          error={lnProxyBudgetHelper() != ''}
+                          helperText={lnProxyBudgetHelper()}
+                          label={t('Proxy Budget')}
+                          value={
+                            lightning.lnproxyBudgetUnit == 'PPM'
+                              ? lightning.lnproxyBudgetPPM
+                              : lightning.lnproxyBudgetSats
+                          }
+                          variant='outlined'
+                          InputProps={{
+                            endAdornment: (
+                              <InputAdornment position='end'>
+                                <Button
+                                  variant='text'
+                                  onClick={() => {
+                                    setLightning({
+                                      ...lightning,
+                                      lnproxyBudgetUnit:
+                                        lightning.lnproxyBudgetUnit == 'PPM' ? 'Sats' : 'PPM',
+                                    });
+                                  }}
+                                >
+                                  {lightning.lnproxyBudgetUnit}
+                                </Button>
+                              </InputAdornment>
+                            ),
+                          }}
+                          inputProps={{
+                            style: {
+                              textAlign: 'center',
+                            },
+                          }}
+                          onChange={onProxyBudgetChange}
+                        />
+                      </Grid>
+
+                      <Grid item>
+                        <Typography variant='body2'>
+                          {t('Submit a valid invoice for {{amountSats}} Satoshis.', {
+                            amountSats: pn(lightning.lnproxyAmount),
+                          })}
+                        </Typography>
+                      </Grid>
+
+                      <Grid item>
+                        <TextField
+                          disabled={!lightning.useLnproxy}
+                          error={lightning.badLnproxy != ''}
+                          helperText={lightning.badLnproxy ? t(lightning.badLnproxy) : ''}
+                          label={t('Invoice to wrap')}
+                          required
+                          value={lightning.lnproxyInvoice}
+                          inputProps={{
+                            style: { textAlign: 'center' },
+                          }}
+                          variant='outlined'
+                          onChange={(e) =>
+                            setLightning({ ...lightning, lnproxyInvoice: e.target.value ?? '' })
+                          }
+                        />
+                      </Grid>
+
+                      <Grid item>
+                        <LoadingButton
+                          loading={loadingLnproxy}
+                          onClick={fetchLnproxy}
+                          variant='outlined'
+                          color='primary'
+                        >
+                          {t('Wrap invoice')}
+                        </LoadingButton>
+                      </Grid>
+                    </Grid>
+                  </Collapse>
+                </Grid>
+              </Grid>
+            </Box>
+          </Tooltip>
         </Collapse>
       </Grid>
 
@@ -215,7 +383,7 @@ export const LightningPayoutForm = ({
           sx={{
             backgroundColor: 'background.paper',
             border: '1px solid',
-            borderRadius: '4px',
+            borderRadius: '0.3em',
             width: '18em',
             borderColor: theme.palette.mode === 'dark' ? '#434343' : '#c4c4c4',
             '&:hover': {
@@ -240,23 +408,83 @@ export const LightningPayoutForm = ({
                   `Set custom routing budget for the payout. If you don't know what this is, simply do not touch.`,
                 )}
               >
-                <FormControlLabel
-                  checked={lightning.useCustomBudget}
-                  onChange={(e) =>
-                    setLightning({ ...lightning, useCustomBudget: e.target.checked })
-                  }
-                  control={<Checkbox />}
-                  label={
-                    <Typography
-                      style={{ display: 'flex', alignItems: 'center' }}
-                      color={lightning.useCustomBudget ? 'primary' : 'text.secondary'}
-                    >
-                      {t('Use custom routing budget')}
-                    </Typography>
-                  }
-                />
+                <div>
+                  <FormControlLabel
+                    checked={lightning.useCustomBudget}
+                    onChange={(e) =>
+                      setLightning({
+                        ...lightning,
+                        useCustomBudget: e.target.checked,
+                        routingBudgetSats: defaultLightning.routingBudgetSats,
+                        routingBudgetPPM: defaultLightning.routingBudgetPPM,
+                      })
+                    }
+                    control={<Checkbox />}
+                    label={
+                      <Typography
+                        style={{ display: 'flex', alignItems: 'center' }}
+                        color={lightning.useCustomBudget ? 'primary' : 'text.secondary'}
+                      >
+                        {t('Use custom routing budget')}
+                      </Typography>
+                    }
+                  />
+                </div>
               </Tooltip>
             </Collapse>
+
+            <Grid item>
+              <Collapse in={lightning.useCustomBudget}>
+                <TextField
+                  sx={{ width: '14em' }}
+                  disabled={!lightning.useCustomBudget}
+                  error={routingBudgetHelper() != ''}
+                  helperText={routingBudgetHelper()}
+                  label={t('Routing Budget')}
+                  required={true}
+                  value={
+                    lightning.routingBudgetUnit == 'PPM'
+                      ? lightning.routingBudgetPPM
+                      : lightning.routingBudgetSats
+                  }
+                  variant='outlined'
+                  InputProps={{
+                    endAdornment: (
+                      <InputAdornment position='end'>
+                        <Button
+                          variant='text'
+                          onClick={() => {
+                            setLightning({
+                              ...lightning,
+                              routingBudgetUnit:
+                                lightning.routingBudgetUnit == 'PPM' ? 'Sats' : 'PPM',
+                            });
+                          }}
+                        >
+                          {lightning.routingBudgetUnit}
+                        </Button>
+                      </InputAdornment>
+                    ),
+                  }}
+                  inputProps={{
+                    style: {
+                      textAlign: 'center',
+                    },
+                  }}
+                  onChange={onRoutingBudgetChange}
+                />
+              </Collapse>
+            </Grid>
+
+            <Grid item>
+              <Collapse in={!lightning.useLnproxy}>
+                <Typography variant='body2'>
+                  {t('Submit a valid invoice for {{amountSats}} Satoshis.', {
+                    amountSats: pn(lightning.amount),
+                  })}
+                </Typography>
+              </Collapse>
+            </Grid>
 
             <Grid item>
               <TextField
@@ -264,14 +492,20 @@ export const LightningPayoutForm = ({
                 disabled={lightning.useLnproxy}
                 error={lightning.badInvoice != ''}
                 helperText={lightning.badInvoice ? t(lightning.badInvoice) : ''}
-                label={t('Payout Lightning Invoice')}
+                label={lightning.useLnproxy ? t('Wrapped invoice') : t('Payout Lightning Invoice')}
                 required
                 value={lightning.invoice}
                 inputProps={{
                   style: { textAlign: 'center', maxHeight: '6em' },
                 }}
-                variant='standard'
-                multiline
+                variant={
+                  lightning.useLnproxy
+                    ? 'filled'
+                    : lightning.useCustomBudget
+                    ? 'outlined'
+                    : 'standard'
+                }
+                multiline={lightning.useLnproxy ? false : true}
                 minRows={2}
                 maxRows={4}
                 onChange={(e) => setLightning({ ...lightning, invoice: e.target.value ?? '' })}
@@ -280,6 +514,7 @@ export const LightningPayoutForm = ({
             <Grid item>
               <LoadingButton
                 loading={loading}
+                disabled={lightning.invoice == ''}
                 onClick={() => onClickSubmit(lightning.invoice)}
                 variant='outlined'
                 color='primary'
@@ -289,6 +524,10 @@ export const LightningPayoutForm = ({
             </Grid>
           </Grid>
         </Box>
+      </Grid>
+
+      <Grid item>
+        <WalletsButton />
       </Grid>
     </Grid>
   );

--- a/frontend/src/components/TradeBox/Forms/LightningPayout.tsx
+++ b/frontend/src/components/TradeBox/Forms/LightningPayout.tsx
@@ -138,7 +138,8 @@ export const LightningPayoutForm = ({
   }, [lightning.lnproxyInvoice, lightning.lnproxyAmount]);
 
   const lnproxyUrl = function () {
-    const bitcoinNetwork = settings.network ?? 'mainnet';
+    console.log(settings);
+    const bitcoinNetwork = settings?.network ?? 'mainnet';
     let internetNetwork: 'Clearnet' | 'I2P' | 'TOR' = 'Clearnet';
     if (settings.host?.includes('.i2p')) {
       internetNetwork = 'I2P';

--- a/frontend/src/components/TradeBox/Prompts/Payout.tsx
+++ b/frontend/src/components/TradeBox/Prompts/Payout.tsx
@@ -4,7 +4,7 @@ import { Grid, Typography, ToggleButtonGroup, ToggleButton } from '@mui/material
 
 import currencies from '../../../../static/assets/currencies.json';
 
-import { Order } from '../../../models';
+import { Order, Settings } from '../../../models';
 import { pn } from '../../../utils';
 import { Bolt, Link } from '@mui/icons-material';
 import { LightningPayoutForm, LightningForm, OnchainPayoutForm, OnchainForm } from '../Forms';
@@ -19,6 +19,7 @@ interface PayoutPrompProps {
   onchain: OnchainForm;
   setOnchain: (state: OnchainForm) => void;
   loadingOnchain: boolean;
+  settings: Settings;
 }
 
 export const PayoutPrompt = ({
@@ -31,6 +32,7 @@ export const PayoutPrompt = ({
   loadingOnchain,
   onchain,
   setOnchain,
+  settings,
 }: PayoutPrompProps): JSX.Element => {
   const { t } = useTranslation();
   const currencyCode: string = currencies[`${order.currency}`];
@@ -97,6 +99,7 @@ export const PayoutPrompt = ({
       <Grid item style={{ display: tab == 'lightning' ? '' : 'none' }}>
         <LightningPayoutForm
           order={order}
+          settings={settings}
           loading={loadingLightning}
           lightning={lightning}
           setLightning={setLightning}

--- a/frontend/src/components/TradeBox/Prompts/Payout.tsx
+++ b/frontend/src/components/TradeBox/Prompts/Payout.tsx
@@ -65,9 +65,9 @@ export const PayoutPrompt = ({
           size='small'
           value={tab}
           exclusive
-          onChange={(mouseEvent, value: string) => setTab(value)}
+          onChange={(mouseEvent, value) => setTab(value == null ? tab : value)}
         >
-          <ToggleButton value='lightning' disableRipple={true}>
+          <ToggleButton value='lightning'>
             <div
               style={{
                 display: 'flex',

--- a/frontend/src/components/TradeBox/Prompts/RoutingFailed.tsx
+++ b/frontend/src/components/TradeBox/Prompts/RoutingFailed.tsx
@@ -28,6 +28,7 @@ const FailureReason = ({ failureReason }: FailureReasonProps): JSX.Element => {
         backgroundColor: theme.palette.background.paper,
         borderRadius: '0.3em',
         border: `1px solid ${theme.palette.text.secondary}`,
+        padding: '0.5em',
       }}
     >
       <Typography variant='body2' align='center'>

--- a/frontend/src/components/TradeBox/Prompts/RoutingFailed.tsx
+++ b/frontend/src/components/TradeBox/Prompts/RoutingFailed.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Box, CircularProgress, Grid, Typography, useTheme } from '@mui/material';
 import Countdown, { CountdownRenderProps, zeroPad } from 'react-countdown';
 
-import { Order } from '../../../models';
+import { Order, Settings } from '../../../models';
 import { LightningForm, LightningPayoutForm } from '../Forms';
 
 interface RoutingFailedPromptProps {
@@ -12,6 +12,7 @@ interface RoutingFailedPromptProps {
   lightning: LightningForm;
   loadingLightning: boolean;
   setLightning: (state: LightningForm) => void;
+  settings: Settings;
 }
 
 interface FailureReasonProps {
@@ -47,6 +48,7 @@ export const RoutingFailedPrompt = ({
   loadingLightning,
   lightning,
   setLightning,
+  settings,
 }: RoutingFailedPromptProps): JSX.Element => {
   const { t } = useTranslation();
 
@@ -96,6 +98,7 @@ export const RoutingFailedPrompt = ({
         <Grid item>
           <LightningPayoutForm
             order={order}
+            settings={settings}
             loading={loadingLightning}
             lightning={lightning}
             setLightning={setLightning}

--- a/frontend/src/components/TradeBox/TradeSummary.tsx
+++ b/frontend/src/components/TradeBox/TradeSummary.tsx
@@ -263,7 +263,7 @@ const TradeSummary = ({
               primary={t('{{revenueSats}} Sats', {
                 revenueSats: pn(platformSummary.trade_revenue_sats),
               })}
-              secondary={t('Platform trade revenue')}
+              secondary={t('Coordinator trade revenue')}
             />
           </ListItem>
 

--- a/frontend/src/components/TradeBox/TradeSummary.tsx
+++ b/frontend/src/components/TradeBox/TradeSummary.tsx
@@ -273,9 +273,9 @@ const TradeSummary = ({
             </ListItemIcon>
             <ListItemText
               primary={t('{{routingFeeSats}} MiliSats', {
-                routingFeeSats: pn(platformSummary.routing_fee_sats),
+                routingFeeSats: pn(platformSummary.routing_budget_sats),
               })}
-              secondary={t('Platform covered routing fee')}
+              secondary={t('Routing budget')}
             />
           </ListItem>
 

--- a/frontend/src/components/TradeBox/index.tsx
+++ b/frontend/src/components/TradeBox/index.tsx
@@ -44,7 +44,7 @@ import {
   defaultDispute,
 } from './Forms';
 
-import { Order } from '../../models';
+import { Order, Settings } from '../../models';
 import { EncryptedChatMessage } from './EncryptedChat';
 import { systemClient } from '../../services/System';
 import CollabCancelAlert from './CollabCancelAlert';
@@ -96,12 +96,14 @@ interface TradeBoxProps {
   setBadOrder: (state: string | undefined) => void;
   onRenewOrder: () => void;
   onStartAgain: () => void;
+  settings: Settings;
   baseUrl: string;
 }
 
 const TradeBox = ({
   order,
   setOrder,
+  settings,
   baseUrl,
   setBadOrder,
   onRenewOrder,
@@ -384,6 +386,7 @@ const TradeBox = ({
           return (
             <PayoutPrompt
               order={order}
+              settings={settings}
               onClickSubmitInvoice={updateInvoice}
               loadingLightning={loadingButtons.submitInvoice}
               lightning={lightning}

--- a/frontend/src/components/TradeBox/index.tsx
+++ b/frontend/src/components/TradeBox/index.tsx
@@ -134,7 +134,7 @@ const TradeBox = ({
       | 'submit_statement'
       | 'rate_platform';
     invoice?: string;
-    routing_budget?: number;
+    routing_budget_ppm?: number;
     address?: string;
     mining_fee_rate?: number;
     statement?: string;
@@ -144,7 +144,7 @@ const TradeBox = ({
   const submitAction = function ({
     action,
     invoice,
-    routing_budget,
+    routing_budget_ppm,
     address,
     mining_fee_rate,
     statement,
@@ -154,7 +154,7 @@ const TradeBox = ({
       .post(baseUrl, '/api/order/?order_id=' + order.id, {
         action,
         invoice,
-        routing_budget,
+        routing_budget_ppm,
         address,
         mining_fee_rate,
         statement,
@@ -204,7 +204,11 @@ const TradeBox = ({
 
   const updateInvoice = function (invoice: string) {
     setLoadingButtons({ ...noLoadingButtons, submitInvoice: true });
-    submitAction({ action: 'update_invoice', invoice, routing_budget: lightning.routingBudgetPPM });
+    submitAction({
+      action: 'update_invoice',
+      invoice,
+      routing_budget_ppm: lightning.routingBudgetPPM,
+    });
   };
 
   const updateAddress = function () {
@@ -255,7 +259,7 @@ const TradeBox = ({
       setWaitingWebln(true);
       setOpen({ ...open, webln: true });
       webln
-        .makeInvoice(lightning.amount)
+        .makeInvoice(() => lightning.amount)
         .then((invoice: any) => {
           if (invoice) {
             updateInvoice(invoice.paymentRequest);
@@ -281,7 +285,7 @@ const TradeBox = ({
   }, [order.status]);
 
   const statusToContract = function (order: Order) {
-    const status = 6;
+    const status = order.status;
     const isBuyer = order.is_buyer;
     const isMaker = order.is_maker;
 

--- a/frontend/src/components/TradeBox/index.tsx
+++ b/frontend/src/components/TradeBox/index.tsx
@@ -434,6 +434,7 @@ const TradeBox = ({
           return (
             <PayoutPrompt
               order={order}
+              settings={settings}
               onClickSubmitInvoice={updateInvoice}
               loadingLightning={loadingButtons.submitInvoice}
               lightning={lightning}
@@ -559,6 +560,7 @@ const TradeBox = ({
           return (
             <RoutingFailedPrompt
               order={order}
+              settings={settings}
               onClickSubmitInvoice={updateInvoice}
               loadingLightning={loadingButtons.submitInvoice}
               lightning={lightning}

--- a/frontend/src/components/TradeBox/index.tsx
+++ b/frontend/src/components/TradeBox/index.tsx
@@ -134,6 +134,7 @@ const TradeBox = ({
       | 'submit_statement'
       | 'rate_platform';
     invoice?: string;
+    routing_budget?: number;
     address?: string;
     mining_fee_rate?: number;
     statement?: string;
@@ -143,6 +144,7 @@ const TradeBox = ({
   const submitAction = function ({
     action,
     invoice,
+    routing_budget,
     address,
     mining_fee_rate,
     statement,
@@ -152,6 +154,7 @@ const TradeBox = ({
       .post(baseUrl, '/api/order/?order_id=' + order.id, {
         action,
         invoice,
+        routing_budget,
         address,
         mining_fee_rate,
         statement,
@@ -201,7 +204,7 @@ const TradeBox = ({
 
   const updateInvoice = function (invoice: string) {
     setLoadingButtons({ ...noLoadingButtons, submitInvoice: true });
-    submitAction({ action: 'update_invoice', invoice });
+    submitAction({ action: 'update_invoice', invoice, routing_budget: lightning.routingBudgetPPM });
   };
 
   const updateAddress = function () {
@@ -252,7 +255,7 @@ const TradeBox = ({
       setWaitingWebln(true);
       setOpen({ ...open, webln: true });
       webln
-        .makeInvoice(order.trade_satoshis)
+        .makeInvoice(lightning.amount)
         .then((invoice: any) => {
           if (invoice) {
             updateInvoice(invoice.paymentRequest);
@@ -278,7 +281,7 @@ const TradeBox = ({
   }, [order.status]);
 
   const statusToContract = function (order: Order) {
-    const status = order.status;
+    const status = 6;
     const isBuyer = order.is_buyer;
     const isMaker = order.is_maker;
 

--- a/frontend/src/models/Coordinator.model.ts
+++ b/frontend/src/models/Coordinator.model.ts
@@ -1,5 +1,6 @@
 export interface Coordinator {
   alias: string;
+  enabled: boolean;
   description: string | undefined;
   coverLetter: string | undefined;
   logo: string;

--- a/frontend/src/models/Order.model.ts
+++ b/frontend/src/models/Order.model.ts
@@ -15,7 +15,7 @@ export interface TradeCoordinatorSummary {
   contract_timestamp: Date;
   contract_total_time: number;
   contract_exchange_rate: number;
-  routing_fee_sats: number;
+  routing_budget_sats: number;
   trade_revenue_sats: number;
 }
 

--- a/frontend/static/federation.json
+++ b/frontend/static/federation.json
@@ -1,9 +1,10 @@
 [
   {
     "alias": "Inception",
+    "enabled": "true",
     "description": "RoboSats original and experimental coordinator",
     "coverLetter": "N/A",
-    "contact_methods": {
+    "contact": {
       "email": "robosats@protonmail.com",
       "telegram": "@robosats",
       "twitter": "@robosats",

--- a/frontend/static/lnproxies.json
+++ b/frontend/static/lnproxies.json
@@ -1,7 +1,11 @@
 [
   {
     "name": "↬ Lnproxy Dev",
-    "mainnetOnion": "rdq6tvulanl7aqtupmoboyk2z3suzkdwurejwyjyjf4itr3zhxrm2lad.onion",
-    "mainnetClearnet": "lnproxy.org"
+    "mainnetClearnet": "lnproxy.org",
+    "mainnetTOR": "rdq6tvulanl7aqtupmoboyk2z3suzkdwurejwyjyjf4itr3zhxrm2lad.onion",
+    "mainnetI2P": "undefined",
+    "testnetClearnet": "undefined",
+    "testnetTOR": "undefined",
+    "testnetI2P": "undefined"
   }
 ]

--- a/frontend/static/lnproxies.json
+++ b/frontend/static/lnproxies.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "↬ Lnproxy Dev",
+    "mainnetOnion": "rdq6tvulanl7aqtupmoboyk2z3suzkdwurejwyjyjf4itr3zhxrm2lad.onion",
+    "mainnetClearnet": "lnproxy.org"
+  }
+]


### PR DESCRIPTION
## What does this PR do?
Adds 2 new options to the Lightning Payout form:
1) Adds UI for fully integrated use of Lnproxy (https://github.com/lnproxy/lnproxy ). Currently only one lnproxy service provider. The form has dropdown to select the lnproxy server (though there is only one). Does not work on testnet or clearnet!

2) Adds Custom routing budget option. This is a long overdue option. With this inclusion, the buyer covers the routing fees. That means, wallets behind expensive private channels can now be used with RoboSats (yet the user must enable "Custom Routing Budget" and enter a sufficient amount manually.

## Checklist before merging
- [x] Make sure you have installed and initialized [pre-commit](https://pre-commit.com). `pip install pre-commit` and `pre-commit install`
