### PR TITLE
Enhance UI for Swaps

### DIFF
--- a/frontend/src/basic/BookPage/index.tsx
+++ b/frontend/src/basic/BookPage/index.tsx
@@ -69,15 +69,6 @@ const BookPage = ({
     }
   }, []);
 
-  const handleCurrencyChange = function (e) {
-    const currency = e.target.value;
-    setFav({ ...fav, currency });
-  };
-
-  const handleTypeChange = function (mouseEvent, val) {
-    setFav({ ...fav, type: val });
-  };
-
   const onOrderClicked = function (id: number) {
     if (hasRobot) {
       history.push('/order/' + id);
@@ -159,13 +150,12 @@ const BookPage = ({
                 clickRefresh={() => fetchBook()}
                 book={book}
                 fav={fav}
+                setFav={setFav}
                 maxWidth={maxBookTableWidth} // EM units
                 maxHeight={windowSize.height * 0.825 - 5} // EM units
                 fullWidth={windowSize.width} // EM units
                 fullHeight={windowSize.height} // EM units
                 defaultFullscreen={false}
-                onCurrencyChange={handleCurrencyChange}
-                onTypeChange={handleTypeChange}
                 onOrderClicked={onOrderClicked}
                 baseUrl={baseUrl}
               />
@@ -199,13 +189,12 @@ const BookPage = ({
             book={book}
             clickRefresh={() => fetchBook()}
             fav={fav}
+            setFav={setFav}
             maxWidth={windowSize.width * 0.97} // EM units
             maxHeight={windowSize.height * 0.825 - 5} // EM units
             fullWidth={windowSize.width} // EM units
             fullHeight={windowSize.height} // EM units
             defaultFullscreen={false}
-            onCurrencyChange={handleCurrencyChange}
-            onTypeChange={handleTypeChange}
             onOrderClicked={onOrderClicked}
             baseUrl={baseUrl}
           />

--- a/frontend/src/basic/Main.tsx
+++ b/frontend/src/basic/Main.tsx
@@ -89,7 +89,7 @@ const Main = ({ settings, setSettings }: MainProps): JSX.Element => {
   const [info, setInfo] = useState<Info>(defaultInfo);
   const [coordinators, setCoordinators] = useState<Coordinator[]>(defaultCoordinators);
   const [baseUrl, setBaseUrl] = useState<string>('');
-  const [fav, setFav] = useState<Favorites>({ type: null, currency: 0 });
+  const [fav, setFav] = useState<Favorites>({ type: null, mode: 'fiat', currency: 0 });
 
   const [delay, setDelay] = useState<number>(60000);
   const [timer, setTimer] = useState<NodeJS.Timer | undefined>(setInterval(() => null, delay));
@@ -456,6 +456,8 @@ const Main = ({ settings, setSettings }: MainProps): JSX.Element => {
             >
               <div>
                 <SettingsPage
+                  fav={fav}
+                  setFav={setFav}
                   settings={settings}
                   setSettings={setSettings}
                   windowSize={{ ...windowSize, height: windowSize.height - navbarHeight }}

--- a/frontend/src/basic/SettingsPage/index.tsx
+++ b/frontend/src/basic/SettingsPage/index.tsx
@@ -2,15 +2,23 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Grid, Paper, useTheme } from '@mui/material';
 import SettingsForm from '../../components/SettingsForm';
-import { Settings } from '../../models';
+import { Settings, Favorites } from '../../models';
 
 interface SettingsPageProps {
+  fav: Favorites;
+  setFav: (state: Favorites) => void;
   settings: Settings;
   setSettings: (state: Settings) => void;
   windowSize: { width: number; height: number };
 }
 
-const SettingsPage = ({ settings, setSettings, windowSize }: SettingsPageProps): JSX.Element => {
+const SettingsPage = ({
+  fav,
+  setFav,
+  settings,
+  setSettings,
+  windowSize,
+}: SettingsPageProps): JSX.Element => {
   const theme = useTheme();
   const { t } = useTranslation();
   const maxHeight = windowSize.height * 0.85 - 3;
@@ -23,6 +31,8 @@ const SettingsPage = ({ settings, setSettings, windowSize }: SettingsPageProps):
       <Grid container>
         <Grid item>
           <SettingsForm
+            fav={fav}
+            setFav={setFav}
             settings={settings}
             setSettings={setSettings}
             showNetwork={!(window.NativeRobosats === undefined)}

--- a/frontend/src/components/BookTable/BookControl.tsx
+++ b/frontend/src/components/BookTable/BookControl.tsx
@@ -9,6 +9,7 @@ import {
   Divider,
   MenuItem,
   Box,
+  Tooltip,
 } from '@mui/material';
 import currencyDict from '../../../static/assets/currencies.json';
 import { useTheme } from '@mui/system';
@@ -80,26 +81,34 @@ const BookControl = ({
         ) : null}
 
         <Grid item>
-          <ToggleButtonGroup
-            sx={{
-              height: '2.6em',
-              backgroundColor: theme.palette.background.paper,
-              border: '0.5px solid',
-              borderColor: 'text.disabled',
-              '&:hover': {
-                borderColor: 'text.primary',
-                border: '1px solid',
-              },
-            }}
-            size='small'
-            exclusive={true}
-            value={fav.mode}
-            onChange={handleModeChange}
+          <Tooltip
+            placement='bottom'
+            enterTouchDelay={200}
+            enterDelay={700}
+            enterNextDelay={2000}
+            title={t('Show Lightning swaps')}
           >
-            <ToggleButton value={'swap'} color={'secondary'}>
-              <SwapCalls />
-            </ToggleButton>
-          </ToggleButtonGroup>
+            <ToggleButtonGroup
+              sx={{
+                height: '2.6em',
+                backgroundColor: theme.palette.background.paper,
+                border: '0.5px solid',
+                borderColor: 'text.disabled',
+                '&:hover': {
+                  borderColor: 'text.primary',
+                  border: '1px solid',
+                },
+              }}
+              size='small'
+              exclusive={true}
+              value={fav.mode}
+              onChange={handleModeChange}
+            >
+              <ToggleButton value={'swap'} color={'secondary'}>
+                <SwapCalls />
+              </ToggleButton>
+            </ToggleButtonGroup>
+          </Tooltip>
         </Grid>
 
         <Grid item>

--- a/frontend/src/components/BookTable/index.tsx
+++ b/frontend/src/components/BookTable/index.tsx
@@ -216,7 +216,10 @@ const BookTable = ({
       field: 'type',
       headerName: t('Is'),
       width: width * fontSize,
-      renderCell: (params: any) => (params.row.type ? t('Seller') : t('Buyer')),
+      renderCell: (params: any) =>
+        params.row.type
+          ? t(fav.mode === 'fiat' ? 'Seller' : 'Swapping Out')
+          : t(fav.mode === 'fiat' ? 'Buyer' : 'Swapping In'),
     };
   };
 
@@ -228,14 +231,15 @@ const BookTable = ({
       type: 'number',
       width: width * fontSize,
       renderCell: (params: any) => {
+        const amount = fav.mode === 'swap' ? params.row.amount * 100000 : params.row.amount;
+        const minAmount =
+          fav.mode === 'swap' ? params.row.min_amount * 100000 : params.row.min_amount;
+        const maxAmount =
+          fav.mode === 'swap' ? params.row.max_amount * 100000 : params.row.max_amount;
         return (
           <div style={{ cursor: 'pointer' }}>
-            {amountToString(
-              params.row.amount,
-              params.row.has_range,
-              params.row.min_amount,
-              params.row.max_amount,
-            )}
+            {amountToString(amount, params.row.has_range, minAmount, maxAmount) +
+              (fav.mode === 'swap' ? 'K Sats' : '')}
           </div>
         );
       },
@@ -244,7 +248,7 @@ const BookTable = ({
 
   const currencyObj = function (width: number, hide: boolean) {
     return {
-      hide,
+      hide: fav.mode === 'swap' ? true : hide,
       field: 'currency',
       headerName: t('Currency'),
       width: width * fontSize,
@@ -495,7 +499,7 @@ const BookTable = ({
       priority: 1,
       order: 4,
       normal: {
-        width: 6.5,
+        width: fav.mode === 'swap' ? 9.5 : 6.5,
         object: amountObj,
       },
     },
@@ -503,7 +507,7 @@ const BookTable = ({
       priority: 2,
       order: 5,
       normal: {
-        width: 5.9,
+        width: fav.mode === 'swap' ? 0 : 5.9,
         object: currencyObj,
       },
     },
@@ -575,7 +579,7 @@ const BookTable = ({
       priority: 10,
       order: 2,
       normal: {
-        width: 4.3,
+        width: fav.mode === 'swap' ? 7 : 4.3,
         object: typeObj,
       },
     },

--- a/frontend/src/components/BookTable/index.tsx
+++ b/frontend/src/components/BookTable/index.tsx
@@ -276,7 +276,7 @@ const BookTable = ({
     return {
       hide,
       field: 'payment_method',
-      headerName: t('Payment Method'),
+      headerName: fav.mode === 'fiat' ? t('Payment Method') : t('Destination'),
       width: width * fontSize,
       renderCell: (params: any) => {
         return (

--- a/frontend/src/components/BookTable/index.tsx
+++ b/frontend/src/components/BookTable/index.tsx
@@ -43,8 +43,7 @@ interface BookTableProps {
   showControls?: boolean;
   showFooter?: boolean;
   showNoResults?: boolean;
-  onCurrencyChange?: (e: any) => void;
-  onTypeChange?: (mouseEvent: any, val: number) => void;
+  setFav?: (state: Favorites) => void;
   onOrderClicked?: (id: number) => void;
   baseUrl: string;
 }
@@ -52,7 +51,8 @@ interface BookTableProps {
 const BookTable = ({
   clickRefresh,
   book,
-  fav = { currency: 1, type: 0 },
+  fav = { currency: 1, type: 0, mode: 'fiat' },
+  setFav,
   maxWidth = 100,
   maxHeight = 70,
   fullWidth = 100,
@@ -63,8 +63,6 @@ const BookTable = ({
   showControls = true,
   showFooter = true,
   showNoResults = true,
-  onCurrencyChange,
-  onTypeChange,
   onOrderClicked = () => null,
   baseUrl,
 }: BookTableProps): JSX.Element => {
@@ -742,10 +740,8 @@ const BookTable = ({
           componentsProps={{
             toolbar: {
               width,
-              type: fav.type,
-              currency: fav.currency,
-              onCurrencyChange,
-              onTypeChange,
+              fav,
+              setFav,
               paymentMethod: paymentMethods,
               setPaymentMethods,
             },

--- a/frontend/src/components/MakerForm/AmountRange.tsx
+++ b/frontend/src/components/MakerForm/AmountRange.tsx
@@ -148,7 +148,7 @@ function AmountRange({
           <Grid
             item
             sx={{
-              width: `calc(100% - ${Math.log10(amountLimits[1] * 0.65) + 2}em)`,
+              width: `calc(100% - ${Math.abs(Math.log10(amountLimits[1]) * 0.65) + 2}em)`,
             }}
           >
             <RangeSlider

--- a/frontend/src/components/MakerForm/MakerForm.tsx
+++ b/frontend/src/components/MakerForm/MakerForm.tsx
@@ -8,6 +8,7 @@ import {
   Switch,
   Tooltip,
   Button,
+  Checkbox,
   Grid,
   Typography,
   TextField,
@@ -146,6 +147,7 @@ const MakerForm = ({
     setFav({
       ...fav,
       currency: newCurrency,
+      mode: newCurrency === 1000 ? 'swap' : 'fiat',
     });
     updateAmountLimits(limits.list, newCurrency, maker.premium);
     updateCurrentPrice(limits.list, newCurrency, maker.premium);
@@ -492,56 +494,79 @@ const MakerForm = ({
       <Collapse in={!collapseAll}>
         <Grid container spacing={1} justifyContent='center' alignItems='center'>
           <Grid item>
-            <FormControl component='fieldset'>
-              <FormHelperText sx={{ textAlign: 'center' }}>
-                {t('Buy or Sell Bitcoin?')}
-              </FormHelperText>
-              <div style={{ textAlign: 'center' }}>
-                <ButtonGroup>
-                  <Button
-                    size={maker.advancedOptions ? 'small' : 'large'}
-                    variant='contained'
-                    onClick={() =>
-                      setFav({
-                        ...fav,
-                        type: 1,
-                      })
-                    }
-                    disableElevation={fav.type == 1}
-                    sx={{
-                      backgroundColor: fav.type == 1 ? 'primary.main' : 'background.paper',
-                      color: fav.type == 1 ? 'background.paper' : 'text.secondary',
-                      ':hover': {
-                        color: 'background.paper',
-                      },
-                    }}
-                  >
-                    {t('Buy')}
-                  </Button>
-                  <Button
-                    size={maker.advancedOptions ? 'small' : 'large'}
-                    variant='contained'
-                    onClick={() =>
-                      setFav({
-                        ...fav,
-                        type: 0,
-                      })
-                    }
-                    disableElevation={fav.type == 0}
-                    color='secondary'
-                    sx={{
-                      backgroundColor: fav.type == 0 ? 'secondary.main' : 'background.paper',
-                      color: fav.type == 0 ? 'background.secondary' : 'text.secondary',
-                      ':hover': {
-                        color: 'background.paper',
-                      },
-                    }}
-                  >
-                    {t('Sell')}
-                  </Button>
-                </ButtonGroup>
-              </div>
-            </FormControl>
+            <Grid container direction='row' justifyContent='center' alignItems='stretch'>
+              <Collapse in={maker.advancedOptions} orientation='horizontal'>
+                <Grid item>
+                  <FormControl>
+                    <FormHelperText sx={{ textAlign: 'center' }}>{t('Swap?')}</FormHelperText>
+                    <Checkbox
+                      sx={{ position: 'relative', bottom: '0.3em' }}
+                      checked={fav.mode == 'swap'}
+                      onClick={() =>
+                        setFav({
+                          ...fav,
+                          mode: fav.mode == 'swap' ? 'fiat' : 'swap',
+                          currency: fav.mode == 'swap' ? 0 : 1000,
+                        })
+                      }
+                    />
+                  </FormControl>
+                </Grid>
+              </Collapse>
+
+              <Grid item>
+                <FormControl component='fieldset'>
+                  <FormHelperText sx={{ textAlign: 'center' }}>
+                    {fav.mode === 'fiat' ? t('Buy or Sell Bitcoin?') : t('In or Out of Lightning?')}
+                  </FormHelperText>
+                  <div style={{ textAlign: 'center' }}>
+                    <ButtonGroup>
+                      <Button
+                        size={maker.advancedOptions ? 'small' : 'large'}
+                        variant='contained'
+                        onClick={() =>
+                          setFav({
+                            ...fav,
+                            type: 1,
+                          })
+                        }
+                        disableElevation={fav.type == 1}
+                        sx={{
+                          backgroundColor: fav.type == 1 ? 'primary.main' : 'background.paper',
+                          color: fav.type == 1 ? 'background.paper' : 'text.secondary',
+                          ':hover': {
+                            color: 'background.paper',
+                          },
+                        }}
+                      >
+                        {fav.mode === 'fiat' ? t('Buy') : t('Swap In')}
+                      </Button>
+                      <Button
+                        size={maker.advancedOptions ? 'small' : 'large'}
+                        variant='contained'
+                        onClick={() =>
+                          setFav({
+                            ...fav,
+                            type: 0,
+                          })
+                        }
+                        disableElevation={fav.type == 0}
+                        color='secondary'
+                        sx={{
+                          backgroundColor: fav.type == 0 ? 'secondary.main' : 'background.paper',
+                          color: fav.type == 0 ? 'background.secondary' : 'text.secondary',
+                          ':hover': {
+                            color: 'background.paper',
+                          },
+                        }}
+                      >
+                        {fav.mode === 'fiat' ? t('Sell') : t('Swap Out')}
+                      </Button>
+                    </ButtonGroup>
+                  </div>
+                </FormControl>
+              </Grid>
+            </Grid>
           </Grid>
 
           <Grid item>
@@ -637,10 +662,10 @@ const MakerForm = ({
             <AutocompletePayments
               onAutocompleteChange={handlePaymentMethodChange}
               // listBoxProps={{ sx: { width: '15.3em', maxHeight: '20em' } }}
-              optionsType={fav.currency == 1000 ? 'swap' : 'fiat'}
+              optionsType={fav.mode}
               error={maker.badPaymentMethod}
               helperText={maker.badPaymentMethod ? t('Must be shorter than 65 characters') : ''}
-              label={fav.currency == 1000 ? t('Swap Destination(s)') : t('Fiat Payment Method(s)')}
+              label={fav.mode == 'swap' ? t('Swap Destination(s)') : t('Fiat Payment Method(s)')}
               tooltipTitle={t(
                 'Enter your preferred fiat payment methods. Fast methods are highly recommended.',
               )}

--- a/frontend/src/components/OrderDetails/TakeButton.tsx
+++ b/frontend/src/components/OrderDetails/TakeButton.tsx
@@ -54,7 +54,7 @@ const TakeButton = ({
   const [loadingTake, setLoadingTake] = useState<boolean>(false);
   const [open, setOpen] = useState<OpenDialogsProps>(closeAll);
 
-  const currencyCode: string = currencies[`${order.currency}`];
+  const currencyCode: string = order.currency == 1000 ? 'Sats' : currencies[`${order.currency}`];
 
   const InactiveMakerDialog = function () {
     return (
@@ -104,9 +104,10 @@ const TakeButton = ({
   };
 
   const amountHelperText = function () {
-    if (Number(takeAmount) < Number(order.min_amount) && takeAmount != '') {
+    const amount = order.currency == 1000 ? Number(takeAmount) / 100000000 : Number(takeAmount);
+    if (amount < Number(order.min_amount) && takeAmount != '') {
       return t('Too low');
-    } else if (Number(takeAmount) > Number(order.max_amount) && takeAmount != '') {
+    } else if (amount > Number(order.max_amount) && takeAmount != '') {
       return t('Too high');
     } else {
       return null;
@@ -122,9 +123,10 @@ const TakeButton = ({
   };
 
   const invalidTakeAmount = function () {
+    const amount = order.currency == 1000 ? Number(takeAmount) / 100000000 : Number(takeAmount);
     return (
-      Number(takeAmount) < Number(order.min_amount) ||
-      Number(takeAmount) > Number(order.max_amount) ||
+      amount < Number(order.min_amount) ||
+      amount > Number(order.max_amount) ||
       takeAmount == '' ||
       takeAmount == null
     );
@@ -155,11 +157,7 @@ const TakeButton = ({
                 title={t('Enter amount of fiat to exchange for bitcoin')}
               >
                 <TextField
-                  error={
-                    (Number(takeAmount) < Number(order.min_amount) ||
-                      Number(takeAmount) > Number(order.max_amount)) &&
-                    takeAmount != ''
-                  }
+                  error={takeAmount === '' ? false : invalidTakeAmount()}
                   helperText={amountHelperText()}
                   label={t('Amount {{currencyCode}}', { currencyCode })}
                   size='small'
@@ -249,7 +247,7 @@ const TakeButton = ({
     apiClient
       .post(baseUrl, '/api/order/?order_id=' + order.id, {
         action: 'take',
-        amount: takeAmount,
+        amount: order.currency == 1000 ? takeAmount / 100000000 : takeAmount,
       })
       .then((data) => {
         setLoadingTake(false);

--- a/frontend/src/components/OrderDetails/TakeButton.tsx
+++ b/frontend/src/components/OrderDetails/TakeButton.tsx
@@ -148,7 +148,7 @@ const TakeButton = ({
           }}
         >
           <Grid container direction='row' alignItems='flex-start' justifyContent='space-evenly'>
-            <Grid item>
+            <Grid item sx={{ width: '12em' }}>
               <Tooltip
                 placement='top'
                 enterTouchDelay={500}

--- a/frontend/src/components/OrderDetails/index.tsx
+++ b/frontend/src/components/OrderDetails/index.tsx
@@ -62,13 +62,18 @@ const OrderDetails = ({
       return (
         amountToString(
           order.amount * 100000000,
-          order.has_range,
+          order.amount ? false : order.has_range,
           order.min_amount * 100000000,
           order.max_amount * 100000000,
         ) + ' Sats'
       );
     } else {
-      return amountToString(order.amount, order.has_range, order.min_amount, order.max_amount);
+      return amountToString(
+        order.amount,
+        order.amount ? false : order.has_range,
+        order.min_amount,
+        order.max_amount,
+      );
     }
   };
 
@@ -212,7 +217,7 @@ const OrderDetails = ({
             </ListItemIcon>
             <ListItemText
               primary={AmountString()}
-              secondary={order.has_range ? 'Amount Range' : 'Amount'}
+              secondary={order.amount && !order.has_range ? 'Amount' : 'Amount Range'}
             />
           </ListItem>
           <Divider />

--- a/frontend/src/components/OrderDetails/index.tsx
+++ b/frontend/src/components/OrderDetails/index.tsx
@@ -32,7 +32,7 @@ import { FlagWithProps } from '../Icons';
 import LinearDeterminate from './LinearDeterminate';
 
 import { Order } from '../../models';
-import { statusBadgeColor, pn } from '../../utils';
+import { statusBadgeColor, pn, amountToString } from '../../utils';
 import { Page } from '../../basic/NavBar';
 import TakeButton from './TakeButton';
 
@@ -58,21 +58,18 @@ const OrderDetails = ({
 
   const AmountString = function () {
     // precision to 8 decimal if currency is BTC otherwise 4 decimals
-    const precision = order.currency == 1000 ? 8 : 4;
-
-    let primary = '';
-    let secondary = '';
-    if (order.has_range && order.amount == null) {
-      const minAmount = pn(parseFloat(Number(order.min_amount).toPrecision(precision)));
-      const maxAmount = pn(parseFloat(Number(order.max_amount).toPrecision(precision)));
-      primary = `${minAmount}-${maxAmount} ${currencyCode}`;
-      secondary = t('Amount range');
+    if (order.currency == 1000) {
+      return (
+        amountToString(
+          order.amount * 100000000,
+          order.has_range,
+          order.min_amount * 100000000,
+          order.max_amount * 100000000,
+        ) + ' Sats'
+      );
     } else {
-      const amount = pn(parseFloat(Number(order.amount).toPrecision(precision)));
-      primary = `${amount} ${currencyCode}`;
-      secondary = t('Amount');
+      return amountToString(order.amount, order.has_range, order.min_amount, order.max_amount);
     }
-    return { primary, secondary };
   };
 
   // Countdown Renderer callback with condition
@@ -151,7 +148,11 @@ const OrderDetails = ({
               />
             </ListItemAvatar>
             <ListItemText
-              primary={order.maker_nick + (order.type ? ' ' + t('(Seller)') : ' ' + t('(Buyer)'))}
+              primary={`${order.maker_nick} (${
+                order.type
+                  ? t(order.currency == 1000 ? 'Swapping Out' : 'Seller')
+                  : t(order.currency == 1000 ? 'Swapping In' : 'Buyer')
+              })`}
               secondary={t('Order maker')}
             />
           </ListItem>
@@ -160,7 +161,11 @@ const OrderDetails = ({
             <Divider />
             <ListItem>
               <ListItemText
-                primary={`${order.taker_nick} ${order.type ? t('(Buyer)') : t('(Seller)')}`}
+                primary={`${order.taker_nick} (${
+                  order.type
+                    ? t(order.currency == 1000 ? 'Swapping In' : 'Buyer')
+                    : t(order.currency == 1000 ? 'Swapping Out' : 'Seller')
+                })`}
                 secondary={t('Order taker')}
               />
               <ListItemAvatar>
@@ -205,7 +210,10 @@ const OrderDetails = ({
                 <FlagWithProps code={currencyCode} width='1.2em' height='1.2em' />
               </div>
             </ListItemIcon>
-            <ListItemText primary={AmountString().primary} secondary={AmountString().secondary} />
+            <ListItemText
+              primary={AmountString()}
+              secondary={order.has_range ? 'Amount Range' : 'Amount'}
+            />
           </ListItem>
           <Divider />
 

--- a/frontend/src/components/SettingsForm/index.tsx
+++ b/frontend/src/components/SettingsForm/index.tsx
@@ -155,7 +155,7 @@ const SettingsForm = ({
               exclusive={true}
               value={fav.mode}
               onChange={(e, mode) => {
-                setFav({ ...fav, mode });
+                setFav({ ...fav, mode, currency: mode === 'fiat' ? 0 : 1000 });
               }}
             >
               <ToggleButton value='fiat' color='primary'>

--- a/frontend/src/components/SettingsForm/index.tsx
+++ b/frontend/src/components/SettingsForm/index.tsx
@@ -14,7 +14,7 @@ import {
   ToggleButtonGroup,
   ToggleButton,
 } from '@mui/material';
-import { Settings } from '../../models';
+import { Favorites, Settings } from '../../models';
 import SelectLanguage from './SelectLanguage';
 import {
   Translate,
@@ -23,11 +23,16 @@ import {
   DarkMode,
   SettingsOverscan,
   Link,
+  AccountBalance,
+  AttachMoney,
 } from '@mui/icons-material';
 import { systemClient } from '../../services/System';
+import SwapCalls from '@mui/icons-material/SwapCalls';
 
 interface SettingsFormProps {
   dense?: boolean;
+  fav: Favorites;
+  setFav: (state: Favorites) => void;
   settings: Settings;
   setSettings: (state: Settings) => void;
   showNetwork?: boolean;
@@ -35,6 +40,8 @@ interface SettingsFormProps {
 
 const SettingsForm = ({
   dense = false,
+  fav,
+  setFav,
   settings,
   setSettings,
   showNetwork = false,
@@ -139,6 +146,29 @@ const SettingsForm = ({
               track={false}
             />
           </ListItem>
+
+          <ListItem>
+            <ListItemIcon>
+              <AccountBalance />
+            </ListItemIcon>
+            <ToggleButtonGroup
+              exclusive={true}
+              value={fav.mode}
+              onChange={(e, mode) => {
+                setFav({ ...fav, mode });
+              }}
+            >
+              <ToggleButton value='fiat' color='primary'>
+                <AttachMoney />
+                {t('Fiat')}
+              </ToggleButton>
+              <ToggleButton value='swap' color='secondary'>
+                <SwapCalls />
+                {t('Swaps')}
+              </ToggleButton>
+            </ToggleButtonGroup>
+          </ListItem>
+
           {showNetwork ? (
             <ListItem>
               <ListItemIcon>

--- a/frontend/src/components/TradeBox/Prompts/LockInvoice.tsx
+++ b/frontend/src/components/TradeBox/Prompts/LockInvoice.tsx
@@ -64,7 +64,7 @@ export const LockInvoicePrompt = ({ order, concept }: LockInvoicePromptProps): J
         <Typography color='secondary' variant='h6' align='center'>
           <b>
             {order.currency == 1000
-              ? t(`You are ${order.is_buyer ? 'SWAPPING INTO' : 'SWAPPING OUT of'} Lightning`)
+              ? t(`${order.is_buyer ? 'SWAPPING INTO' : 'SWAPPING OUT of'} Lightning`)
               : t(`You are ${order.is_buyer ? 'BUYING' : 'SELLING'} BTC`)}
           </b>
         </Typography>

--- a/frontend/src/components/TradeBox/Prompts/LockInvoice.tsx
+++ b/frontend/src/components/TradeBox/Prompts/LockInvoice.tsx
@@ -56,17 +56,21 @@ export const LockInvoicePrompt = ({ order, concept }: LockInvoicePromptProps): J
       alignItems='center'
       spacing={0.5}
     >
+      <Grid item xs={12}>
+        {concept === 'bond' ? <WalletsButton /> : <ExpirationWarning />}
+      </Grid>
+
       {concept == 'bond' ? (
-        <Typography color='secondary'>
-          <b>{t(`You are ${order.is_buyer ? 'BUYING' : 'SELLING'} BTC`)}</b>
+        <Typography color='secondary' variant='h6' align='center'>
+          <b>
+            {order.currency == 1000
+              ? t(`You are ${order.is_buyer ? 'SWAPPING INTO' : 'SWAPPING OUT of'} Lightning`)
+              : t(`You are ${order.is_buyer ? 'BUYING' : 'SELLING'} BTC`)}
+          </b>
         </Typography>
       ) : (
         <></>
       )}
-
-      <Grid item xs={12}>
-        {concept === 'bond' ? <WalletsButton /> : <ExpirationWarning />}
-      </Grid>
 
       <Grid item xs={12}>
         <Tooltip disableHoverListener enterTouchDelay={0} title={t('Copied!')}>

--- a/frontend/src/components/TradeBox/Prompts/Payout.tsx
+++ b/frontend/src/components/TradeBox/Prompts/Payout.tsx
@@ -54,9 +54,13 @@ export const PayoutPrompt = ({
             'Before letting you send {{amountFiat}} {{currencyCode}}, we want to make sure you are able to receive the BTC.',
             {
               amountFiat: pn(
-                parseFloat(parseFloat(order.amount).toFixed(order.currency == 1000 ? 8 : 4)),
+                parseFloat(
+                  parseFloat(
+                    order.currency == 1000 ? order.amount * 100000000 : order.amount,
+                  ).toFixed(4),
+                ),
               ),
-              currencyCode,
+              currencyCode: order.currency == 1000 ? 'Sats' : currencyCode,
             },
           )}
         </Typography>

--- a/frontend/src/models/Favorites.model.ts
+++ b/frontend/src/models/Favorites.model.ts
@@ -1,5 +1,6 @@
 export interface Favorites {
   type: number | null;
+  mode: 'swap' | 'fiat';
   currency: number;
 }
 

--- a/frontend/src/utils/filterOrders.ts
+++ b/frontend/src/utils/filterOrders.ts
@@ -50,11 +50,12 @@ const filterOrders = function ({
 }: FilterOrders) {
   const filteredOrders = orders.filter((order) => {
     const typeChecks = order.type == baseFilter.type || baseFilter.type == null;
+    const modeChecks = baseFilter.mode === 'fiat' ? !(order.currency === 1000) : true;
     const currencyChecks = order.currency == baseFilter.currency || baseFilter.currency == 0;
     const paymentMethodChecks =
       paymentMethods.length > 0 ? filterByPayment(order, paymentMethods) : true;
     const amountChecks = amountFilter != null ? filterByAmount(order, amountFilter) : true;
-    return typeChecks && currencyChecks && paymentMethodChecks && amountChecks;
+    return typeChecks && modeChecks && currencyChecks && paymentMethodChecks && amountChecks;
   });
   return filteredOrders;
 };

--- a/frontend/src/utils/prettyNumbers.ts
+++ b/frontend/src/utils/prettyNumbers.ts
@@ -15,15 +15,16 @@ export const amountToString: (
   has_range: boolean,
   min_amount: number,
   max_amount: number,
-) => string = (amount, has_range, min_amount, max_amount) => {
+  precision?: number,
+) => string = (amount, has_range, min_amount, max_amount, precision = 4) => {
   if (has_range) {
     return (
-      pn(parseFloat(Number(min_amount).toPrecision(4))) +
+      pn(parseFloat(Number(min_amount).toPrecision(precision))) +
       '-' +
-      pn(parseFloat(Number(max_amount).toPrecision(4)))
+      pn(parseFloat(Number(max_amount).toPrecision(precision)))
     );
   }
-  return pn(parseFloat(Number(amount).toPrecision(4))) || '';
+  return pn(parseFloat(Number(amount).toPrecision(precision))) || '';
 };
 
 export default pn;


### PR DESCRIPTION
## What does this PR do?
This PR introduces an overhaul to improve user experience when using RoboSats for Swaps. 
- New Fav parameter "mode" (either `fiat` or `swap` ) is used to switch the UI to adapt to the selected method.
- New dedicated switches for Swap/Fiat have been introduced in the Settings form, Book table and Maker form.
- Swaps are now denominated in Sats
- Redundant info is hidden when swap mode is enabled.
- Order page uses swap specific language when swap mode is enabled.

## Checklist before merging
- [x] Make sure you have installed and initialized [pre-commit](https://pre-commit.com). `pip install pre-commit` and `pre-commit install`
