### PR TITLE
Deprecate old routing budget pipeline

### DIFF
--- a/api/lightning/node.py
+++ b/api/lightning/node.py
@@ -283,14 +283,12 @@ class LNNode:
         route_hints = payreq_decoded.route_hints
 
         # Max amount RoboSats will pay for routing
-        # Start deprecate after v0.3.1 (only else max_routing_fee_sats will remain)
         if routing_budget_ppm == 0:
             max_routing_fee_sats = max(
                 num_satoshis * float(config("PROPORTIONAL_ROUTING_FEE_LIMIT")),
                 float(config("MIN_FLAT_ROUTING_FEE_LIMIT_REWARD")),
             )
         else:
-            # End deprecate
             max_routing_fee_sats = int(
                 float(num_satoshis) * float(routing_budget_ppm) / 1000000
             )

--- a/api/logics.py
+++ b/api/logics.py
@@ -1738,19 +1738,10 @@ class Logics:
             )
         if not order.is_swap:
             platform_summary["routing_budget_sats"] = order.payout.routing_budget_sats
-            # Start Deprecated after v0.3.1
-            platform_summary["routing_fee_sats"] = order.payout.fee
-            # End Deprecated after v0.3.1
             platform_summary["trade_revenue_sats"] = int(
                 order.trade_escrow.num_satoshis
                 - order.payout.num_satoshis
-                # Start Deprecated after v0.3.1 (will be `- order.payout.routing_budget_sats`)
-                - (
-                    order.payout.fee
-                    if order.payout.routing_budget_sats == 0
-                    else order.payout.routing_budget_sats
-                )
-                # End Deprecated after v0.3.1
+                - order.payout.routing_budget_sats
             )
         else:
             platform_summary["routing_fee_sats"] = 0

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -86,23 +86,11 @@ def follow_send_payment(hash):
     from api.models import LNPayment, Order
 
     lnpayment = LNPayment.objects.get(payment_hash=hash)
-    # Start deprecate after v0.3.1 (only else max_routing_fee_sats will remain)
-    if lnpayment.routing_budget_ppm == 0:
-        fee_limit_sat = int(
-            max(
-                lnpayment.num_satoshis
-                * float(config("PROPORTIONAL_ROUTING_FEE_LIMIT")),
-                float(config("MIN_FLAT_ROUTING_FEE_LIMIT")),
-            )
-        )  # 1000 ppm or 10 sats
-    else:
-        # End deprecate
-        # Defaults is 0ppm. Set by the user over API. Defaults to 1000 ppm on ReactJS frontend.
-        fee_limit_sat = int(
-            float(lnpayment.num_satoshis)
-            * float(lnpayment.routing_budget_ppm)
-            / 1000000
-        )
+
+    # Default is 0ppm. Set by the user over API. Client's default is 1000 ppm.
+    fee_limit_sat = int(
+        float(lnpayment.num_satoshis) * float(lnpayment.routing_budget_ppm) / 1000000
+    )
     timeout_seconds = int(config("PAYOUT_TIMEOUT_SECONDS"))
 
     request = LNNode.routerrpc.SendPaymentRequest(

--- a/api/views.py
+++ b/api/views.py
@@ -285,9 +285,6 @@ class OrderView(viewsets.ViewSet):
                         currency=order.currency, status=Order.Status.PUB
                     )
                 )
-                # Adds/generate telegram token and whether it is enabled
-                # Deprecated
-                data = {**data, **Telegram.get_context(request.user)}
 
         # For participants add positions, nicks and status as a message and hold invoices status
         data["is_buyer"] = Logics.is_buyer(order, request.user)
@@ -441,11 +438,6 @@ class OrderView(viewsets.ViewSet):
             if order.payout.status == LNPayment.Status.EXPIRE:
                 data["invoice_expired"] = True
                 # Add invoice amount once again if invoice was expired.
-                # Start deprecate after v0.3.1
-                data["invoice_amount"] = Logics.payout_amount(order, request.user)[1][
-                    "invoice_amount"
-                ]
-                # End deprecate
                 data["trade_satoshis"] = Logics.payout_amount(order, request.user)[1][
                     "invoice_amount"
                 ]
@@ -642,23 +634,6 @@ class UserView(APIView):
         if not serializer.is_valid():
             context = {"bad_request": "Invalid serializer"}
             return Response(context, status=status.HTTP_400_BAD_REQUEST)
-
-        # Deprecated
-        #
-        # If an existing user opens the main page by mistake, we do not want it to create a new nickname/profile for him
-        # if request.user.is_authenticated:
-        #     context = {"nickname": request.user.username}
-        #     not_participant, _, order = Logics.validate_already_maker_or_taker(
-        #         request.user
-        #     )
-
-        #     # Does not allow this 'mistake' if an active order
-        #     if not not_participant:
-        #         context["active_order_id"] = order.id
-        #         context[
-        #             "bad_request"
-        #         ] = f"You are already logged in as {request.user} and have an active order"
-        #         return Response(context, status.HTTP_400_BAD_REQUEST)
 
         # The new way. The token is never sent. Only its SHA256
         token_sha256 = serializer.data.get("token_sha256")


### PR DESCRIPTION
## What does this PR do?
When the advanced options for buyer payouts was implemented, a new feature that allowed users to select the routing budget was implemented. This allowed users to receive in some previously incompatible wallets such as Muun. The change made any existing client incompatible, therefore, both pipelines have been supported by the coordinator until now. With this PR, the old routing budget mechanics are no longer supported. 

TLDR; Clients older than 0.3.1 are 'incompatible'. These only will submit buyer payout requests with a routing budget of 0ppm!

## Checklist before merging
- [x] Make sure you have installed and initialized [pre-commit](https://pre-commit.com). `pip install pre-commit` and `pre-commit install`
