### PR TITLE
Capture HTTP errors on Android

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -54,16 +54,18 @@ const App = () => {
   };
 
   const onCatch = (dataId: string, event: any) => {
-    let json = '{}'
+    let json = '{}';
     if (event.message) {
-      const reponse = /Request Response Code \((?<code>\d*)\)\: (?<json>\{.*\})/.exec(event.message)
-      json = reponse?.groups?.json ?? '{}'
+      const reponse = /Request Response Code \((?<code>\d*)\)\: (?<json>\{.*\})/.exec(
+        event.message,
+      );
+      json = reponse?.groups?.json ?? '{}';
     }
     injectMessageResolve(dataId, {
       headers: {},
-      json: JSON.parse(json)
+      json: JSON.parse(json),
     });
-  }
+  };
 
   const onMessage = async (event: WebViewMessageEvent) => {
     const data = JSON.parse(event.nativeEvent.data);

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -53,6 +53,18 @@ const App = () => {
     loadCookie('garage').then(() => injectMessageResolve(reponseId));
   };
 
+  const onCatch = (dataId: string, event: any) => {
+    let json = '{}'
+    if (event.message) {
+      const reponse = /Request Response Code \((?<code>\d*)\)\: (?<json>\{.*\})/.exec(event.message)
+      json = reponse?.groups?.json ?? '{}'
+    }
+    injectMessageResolve(dataId, {
+      headers: {},
+      json: JSON.parse(json)
+    });
+  }
+
   const onMessage = async (event: WebViewMessageEvent) => {
     const data = JSON.parse(event.nativeEvent.data);
     if (data.category === 'http') {
@@ -63,7 +75,7 @@ const App = () => {
           .then((response: object) => {
             injectMessageResolve(data.id, response);
           })
-          .catch(sendTorStatus)
+          .catch((e) => onCatch(data.id, e))
           .finally(sendTorStatus);
       } else if (data.type === 'post') {
         torClient
@@ -71,7 +83,7 @@ const App = () => {
           .then((response: object) => {
             injectMessageResolve(data.id, response);
           })
-          .catch(sendTorStatus)
+          .catch((e) => onCatch(data.id, e))
           .finally(sendTorStatus);
       } else if (data.type === 'delete') {
         torClient
@@ -79,7 +91,7 @@ const App = () => {
           .then((response: object) => {
             injectMessageResolve(data.id, response);
           })
-          .catch(sendTorStatus)
+          .catch((e) => onCatch(data.id, e))
           .finally(sendTorStatus);
       } else if (data.type === 'xhr') {
         torClient
@@ -87,7 +99,7 @@ const App = () => {
           .then((response: object) => {
             injectMessageResolve(data.id, response);
           })
-          .catch(sendTorStatus)
+          .catch((e) => onCatch(data.id, e))
           .finally(sendTorStatus);
       }
     } else if (data.category === 'system') {
@@ -116,7 +128,7 @@ const App = () => {
     } catch (error) {}
   };
 
-  const sendTorStatus = async () => {
+  const sendTorStatus = async (event?: any) => {
     NetInfo.fetch().then(async (state) => {
       let daemonStatus = 'ERROR';
       if (state.isInternetReachable) {

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -55,14 +55,17 @@ const App = () => {
 
   const onCatch = (dataId: string, event: any) => {
     let json = '{}';
+    let code = 500;
     if (event.message) {
       const reponse = /Request Response Code \((?<code>\d*)\)\: (?<json>\{.*\})/.exec(
         event.message,
       );
       json = reponse?.groups?.json ?? '{}';
+      code = reponse?.groups?.code ?  parseInt(reponse?.groups?.code) : 500;
     }
     injectMessageResolve(dataId, {
       headers: {},
+      respCode: code,
       json: JSON.parse(json),
     });
   };


### PR DESCRIPTION
## What does this PR do?
Fixes #376

This PR makes react-native to capture and return error responses to the JS app

## Checklist before merging
- [x] If it's a frontend feature, I have ran prettier `cd frontend; npm run format`. If it's a mobile app feature I ran `cd mobile; npm run format`.
- [ ] If I added new phrases to the user interface, I have ran prettier `cd frontend/static/locales; python collect_phrases.py` to collect them for translation.