### PR TITLE
Fixed npub address

### DIFF
--- a/docs/_pages/contribute/07-donate.md
+++ b/docs/_pages/contribute/07-donate.md
@@ -18,8 +18,9 @@ You can donate the following ways:
  - **Zap us on Nostr:**
  All Nostr zaps will go towards the social media team.  
  Here is the nPub for RoboSats account :
+ 
  ```
-npub1r4tqzq5hryyh0k9z3y8de959hrkvye0rqlk3g2ps80w03cpqhhwshnxnmy
+npub1p2psats79rypr8lpnl9t5qdekfp700x660qsgw284xvq4s09lqrqqk3m82
  ``` 
 
  - **Directly tip the developer working on the features you like.** Check the [active PRs](https://github.com/Reckless-Satoshi/robosats/pulls) and show your support to the developers with via Lightning tips. Simply write a message, for example "@developer_name, I would like to fund your development of this feature with 6000 Sats". The developer should reply with a LN invoice with a long expiration time.


### PR DESCRIPTION
Had the npub for the Robosats order bot in there previously. Changed to the official Robosats npub.