### PR TITLE
Add multi architecture Android builds and reduce bundle sizes

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -63,6 +63,14 @@ jobs:
         uses: pr-mpt/actions-commit-hash@v1
 
       # Create artifacts (only for Release)
+      # Create app-universal-release APK artifact asset for Release
+      - name: 'Upload universal .apk Release Artifact (for Release)'
+        uses: actions/upload-artifact@v3
+        if: inputs.semver != ''  # If this workflow is called from release.yml
+        with:
+          name: robosats-${{ inputs.semver }}-universal.apk
+          path: mobile/android/app/build/outputs/apk/release/app-universal-release.apk
+
       # Create app-arm64-v8a-release APK artifact asset for Release
       - name: 'Upload arm64-v8a .apk Release Artifact (for Release)'
         uses: actions/upload-artifact@v3
@@ -107,6 +115,19 @@ jobs:
           changelog: mobile/CHANGELOG.md
           draft: false
           prerelease: true
+
+      # Upload universal APK to pre-release
+      - name: 'Upload universal Pre-release APK Asset'
+        id: upload-release-universal-apk-asset
+        if: inputs.semver == '' # only if this workflow is not called from a push to tag (a Release)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./mobile/android/app/build/outputs/apk/release/app-universal-release.apk
+          asset_name: robosats-${{ steps.commit.outputs.short }}-universal.apk
+          asset_content_type: application/apk
 
       # Upload arm64-v8a APK to pre-release
       - name: 'Upload arm64-v8a Pre-release APK Asset'

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -53,12 +53,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
-      # - name: 'Build Android Debug'
-      #   if: inputs.semver == ''  # Only build debug if this is a pre-release
-      #   run: |
-      #     cd mobile/android
-      #     ./gradlew assembleDebug
-
       - name: 'Build Android Release'
         run: |
           cd mobile/android
@@ -68,26 +62,38 @@ jobs:
         id: commit
         uses: pr-mpt/actions-commit-hash@v1
 
-      - name: 'Upload .apk Release Artifact (for Release)'
+      # Create artifacts (only for Release)
+      # Create app-arm64-v8a-release APK artifact asset for Release
+      - name: 'Upload arm64-v8a .apk Release Artifact (for Release)'
         uses: actions/upload-artifact@v3
         if: inputs.semver != ''  # If this workflow is called from release.yml
         with:
-          name: robosats-${{ inputs.semver }}.apk
-          path: mobile/android/app/build/outputs/apk/release/app-release.apk
+          name: robosats-${{ inputs.semver }}-arm64-v8a.apk
+          path: mobile/android/app/build/outputs/apk/release/app-arm64-v8a-release.apk
 
-      - name: 'Upload .apk Artifact (for Pre-release)'
+      # Create app-armeabi-v7a-release APK artifact asset for Release
+      - name: 'Upload armeabi-v7a .apk Release Artifact (for Release)'
         uses: actions/upload-artifact@v3
-        if: inputs.semver == ''  # only if this workflow is not called from a push to tag (a Release)
+        if: inputs.semver != ''  # If this workflow is called from release.yml
         with:
-          name: robosats-${{ steps.commit.outputs.short }}.apk
-          path: mobile/android/app/build/outputs/apk/release/app-release.apk
+          name: robosats-${{ inputs.semver }}-armeabi-v7a.apk
+          path: mobile/android/app/build/outputs/apk/release/app-armeabi-v7a-release.apk
 
-      # - name: 'Upload .apk Debug Artifact (for Pre-release)'
-      #   if: inputs.semver == ''  # Only build debug if this is a pre-release
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     name: robosats-debug-${{ steps.commit.outputs.short }}.apk
-      #     path: mobile/android/app/build/outputs/apk/debug/app-debug.apk
+      # Create app-x86_64-release APK artifact asset for Release
+      - name: 'Upload x86_64 .apk Release Artifact (for Release)'
+        uses: actions/upload-artifact@v3
+        if: inputs.semver != ''  # If this workflow is called from release.yml
+        with:
+          name: robosats-${{ inputs.semver }}-x86_64.apk
+          path: mobile/android/app/build/outputs/apk/release/app-x86_64-release.apk
+
+      # Create app-x86-release APK artifact asset for Release
+      - name: 'Upload x86 .apk Release Artifact (for Release)'
+        uses: actions/upload-artifact@v3
+        if: inputs.semver != ''  # If this workflow is called from release.yml
+        with:
+          name: robosats-${{ inputs.semver }}-x86.apk
+          path: mobile/android/app/build/outputs/apk/release/app-x86-release.apk
 
       - name: 'Create Pre-release'
         id: create_release
@@ -102,26 +108,54 @@ jobs:
           draft: false
           prerelease: true
 
-      - name: 'Upload Pre-release APK Release Asset'
-        id: upload-release-apk-asset
+      # Upload arm64-v8a APK to pre-release
+      - name: 'Upload arm64-v8a Pre-release APK Asset'
+        id: upload-release-arm64-v8a-apk-asset
         if: inputs.semver == '' # only if this workflow is not called from a push to tag (a Release)
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./mobile/android/app/build/outputs/apk/release/app-release.apk
-          asset_name: robosats-${{ steps.commit.outputs.short }}.apk
+          asset_path: ./mobile/android/app/build/outputs/apk/release/app-arm64-v8a-release.apk
+          asset_name: robosats-${{ steps.commit.outputs.short }}-arm64-v8a.apk
           asset_content_type: application/apk
 
-      # - name: 'Upload Pre-release APK Debug Asset'
-      #   id: upload-debug-apk-asset
-      #   if: inputs.semver == '' # only if this workflow is not called from a push to tag (a Release)
-      #   uses: actions/upload-release-asset@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-      #     asset_path: ./mobile/android/app/build/outputs/apk/debug/app-debug.apk
-      #     asset_name: robosats-debug-${{ steps.commit.outputs.short }}.apk
-      #     asset_content_type: application/apk
+      # Upload armeabi-v7a APK to pre-release
+      - name: 'Upload armeabi-v7a Pre-release APK Asset'
+        id: upload-release-armeabi-v7a-apk-asset
+        if: inputs.semver == '' # only if this workflow is not called from a push to tag (a Release)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./mobile/android/app/build/outputs/apk/release/app-armeabi-v7a-release.apk
+          asset_name: robosats-${{ steps.commit.outputs.short }}-armeabi-v7a.apk
+          asset_content_type: application/apk
+
+      # Upload x86_64 APK to pre-release
+      - name: 'Upload x86_64 Pre-release APK Asset'
+        id: upload-release-x86_64-apk-asset
+        if: inputs.semver == '' # only if this workflow is not called from a push to tag (a Release)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./mobile/android/app/build/outputs/apk/release/app-x86_64-release.apk
+          asset_name: robosats-${{ steps.commit.outputs.short }}-x86_64.apk
+          asset_content_type: application/apk
+
+      # Upload x86 APK to pre-release
+      - name: 'Upload x86 Pre-release APK Asset'
+        id: upload-release-x86-apk-asset
+        if: inputs.semver == '' # only if this workflow is not called from a push to tag (a Release)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./mobile/android/app/build/outputs/apk/release/app-x86-release.apk
+          asset_name: robosats-${{ steps.commit.outputs.short }}-x86.apk
+          asset_content_type: application/apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,23 @@ jobs:
         with:
           body: ${{ steps.changelog.outputs.changelog }}
 
+      # Upload app-universal-release APK artifact asset
+      - name: 'Download universal APK Artifact'
+        uses: actions/download-artifact@v3
+        with:
+          name: robosats-${{ needs.check-versions.outputs.semver }}-universal.apk
+          path: .
+      - name: 'Upload universal APK Asset'
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: app-universal-release.apk
+          asset_name: robosats-${{ needs.check-versions.outputs.semver }}-universal.apk
+          asset_content_type: application/apk
+
       # Upload app-arm64-v8a-release APK artifact asset
       - name: 'Download arm64-v8a APK Artifact'
         uses: actions/download-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,19 +83,70 @@ jobs:
         with:
           body: ${{ steps.changelog.outputs.changelog }}
 
-      # Upload APK artifact asset
-      - name: 'Download APK Artifact'
+      # Upload app-arm64-v8a-release APK artifact asset
+      - name: 'Download arm64-v8a APK Artifact'
         uses: actions/download-artifact@v3
         with:
-          name: robosats-${{ needs.check-versions.outputs.semver }}.apk
+          name: robosats-${{ needs.check-versions.outputs.semver }}-arm64-v8a.apk
           path: .
-      - name: 'Upload APK Asset'
+      - name: 'Upload arm64-v8a APK Asset'
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: app-release.apk
-          asset_name: robosats-${{ needs.check-versions.outputs.semver }}.apk
+          asset_path: app-arm64-v8a-release.apk
+          asset_name: robosats-${{ needs.check-versions.outputs.semver }}-arm64-v8a.apk
+          asset_content_type: application/apk
+
+      # Upload app-armeabi-v7a-release APK artifact asset
+      - name: 'Download armeabi-v7a APK Artifact'
+        uses: actions/download-artifact@v3
+        with:
+          name: robosats-${{ needs.check-versions.outputs.semver }}-armeabi-v7a.apk
+          path: .
+      - name: 'Upload armeabi-v7a APK Asset'
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: app-armeabi-v7a-release.apk
+          asset_name: robosats-${{ needs.check-versions.outputs.semver }}-armeabi-v7a.apk
+          asset_content_type: application/apk
+
+      # Upload app-x86_64-release APK artifact asset
+      - name: 'Download x86_64 APK Artifact'
+        uses: actions/download-artifact@v3
+        with:
+          name: robosats-${{ needs.check-versions.outputs.semver }}-x86_64.apk
+          path: .
+      - name: 'Upload x86_64 APK Asset'
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: app-x86_64-release.apk
+          asset_name: robosats-${{ needs.check-versions.outputs.semver }}-x86_64.apk
+          asset_content_type: application/apk
+
+      # Upload app-x86-release APK artifact asset
+      - name: 'Download x86 APK Artifact'
+        uses: actions/download-artifact@v3
+        with:
+          name: robosats-${{ needs.check-versions.outputs.semver }}-x86.apk
+          path: .
+      - name: 'Upload x86 APK Asset'
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: app-x86-release.apk
+          asset_name: robosats-${{ needs.check-versions.outputs.semver }}-x86.apk
           asset_content_type: application/apk

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -91,12 +91,12 @@ apply from: "../../node_modules/react-native/react.gradle"
  * Upload all the APKs to the Play Store and people will download
  * the correct one based on the CPU architecture of their device.
  */
-def enableSeparateBuildPerCPUArchitecture = false
+def enableSeparateBuildPerCPUArchitecture = true
 
 /**
  * Run Proguard to shrink the Java bytecode in release builds.
  */
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 /**
  * The preferred build flavor of JavaScriptCore.

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -96,7 +96,7 @@ def enableSeparateBuildPerCPUArchitecture = true
 /**
  * Run Proguard to shrink the Java bytecode in release builds.
  */
-def enableProguardInReleaseBuilds = true
+def enableProguardInReleaseBuilds = false
 
 /**
  * The preferred build flavor of JavaScriptCore.

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -224,7 +224,7 @@ android {
         abi {
             reset()
             enable enableSeparateBuildPerCPUArchitecture
-            universalApk false  // If true, also generate a universal APK
+            universalApk true  // If true, also generate a universal APK
             include (*reactNativeArchitectures())
         }
     }

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "robosats",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "robosats",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@react-native-clipboard/clipboard": "^1.11.1",
         "@react-native-community/netinfo": "^9.3.4",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robosats",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
## What does this PR do?
Enables separate builds per CPU architecture and re-factors build and release github workflows to upload the multiple bundles.

Proguard remains disabled as discovering the rules needed for the app not to crash seems a daunting task for the ~5-10% smaller bundle sized.

## Checklist before merging
- [ ] If it's a frontend feature, I have ran prettier `cd frontend; npm run format`. If it's a mobile app feature I ran `cd mobile; npm run format`.
- [ ] If I added new phrases to the user interface, I have ran prettier `cd frontend/static/locales; python collect_phrases.py` to collect them for translation.