### PR TITLE
Fix parameter typo

### DIFF
--- a/frontend/src/basic/BookPage/index.tsx
+++ b/frontend/src/basic/BookPage/index.tsx
@@ -92,7 +92,7 @@ const BookPage = (): JSX.Element => {
         <Dialog open={openMaker} onClose={() => setOpenMaker(false)}>
           <Box sx={{ maxWidth: '18em', padding: '0.5em' }}>
             <MakerForm
-              hasRobot={robot.AvatarLoaded}
+              hasRobot={robot.avatarLoaded}
               onOrderCreated={(id) => {
                 clearOrder();
                 setCurrentOrder(id);


### PR DESCRIPTION
## What does this PR do?
Fixes https://github.com/Reckless-Satoshi/robosats/issues/414

This PR fixes a `hasRobot` parameter typo that was causing the MakerForm to use the default value (true).

## Checklist before merging
- [x] If it's a frontend feature, I have ran prettier `cd frontend; npm run format`. If it's a mobile app feature I ran `cd mobile; npm run format`.
- [x] If I added new phrases to the user interface, I have ran prettier `cd frontend/static/locales; python collect_phrases.py` to collect them for translation.