### PR TITLE
Add error boundary

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import i18n from './i18n/Web';
 
 import { systemClient } from './services/System';
 import { Settings } from './models';
+import ErrorBoundary from './components/ErrorBoundary';
 
 const makeTheme = function (settings: Settings) {
   const theme: Theme = createTheme({
@@ -40,17 +41,19 @@ const App = (): JSX.Element => {
   }, []);
 
   return (
-    <Suspense fallback='loading language'>
-      <I18nextProvider i18n={i18n}>
-        <ThemeProvider theme={theme}>
-          <AppContextProvider settings={settings} setSettings={setSettings}>
-            <CssBaseline />
-            {window.NativeRobosats === undefined ? <UnsafeAlert /> : <TorConnectionBadge />}
-            <Main />
-          </AppContextProvider>
-        </ThemeProvider>
-      </I18nextProvider>
-    </Suspense>
+    <ErrorBoundary>
+      <Suspense fallback='loading language'>
+        <I18nextProvider i18n={i18n}>
+          <ThemeProvider theme={theme}>
+            <AppContextProvider settings={settings} setSettings={setSettings}>
+              <CssBaseline />
+              {window.NativeRobosats === undefined ? <UnsafeAlert /> : <TorConnectionBadge />}
+              <Main />
+            </AppContextProvider>
+          </ThemeProvider>
+        </I18nextProvider>
+      </Suspense>
+    </ErrorBoundary>
   );
 };
 

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,52 @@
+import React, { Component } from 'react';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error;
+  errorInfo: React.ErrorInfo;
+}
+
+export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: { name: '', message: '' },
+      errorInfo: { componentStack: '' },
+    };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    console.error(error, errorInfo);
+    this.setState({ hasError: true, error, errorInfo });
+    setTimeout(() => {
+      window.location.reload();
+    }, 10000);
+  }
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div>
+          <h1>Something went wrong. Restarting app in 10 seconds...</h1>
+          <p>
+            <b>Error:</b> {this.state.error.name}
+          </p>
+          <p>
+            <b>Error message:</b> {this.state.error.message}
+          </p>
+          <p>
+            <b>Error cause:</b> {this.state.error.cause}
+          </p>
+          <p>
+            <b>Error component stack:</b> {this.state.errorInfo.componentStack}
+          </p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## What does this PR do?
Adds a simply class component that wraps the entire app with an error boundary. In case of uncaught error, that will crash the app and render a white screen, it will instead display the error message for 10 seconds then proceed to restart the app.

## Checklist before merging
- [x] If it's a frontend feature, I have ran prettier `cd frontend; npm run format`. If it's a mobile app feature I ran `cd mobile; npm run format`.
- [x] If I added new phrases to the user interface, I have ran prettier `cd frontend/static/locales; python collect_phrases.py` to collect them for translation.