### PR TITLE
Refactor LNNode, use versioner for LND get_version, refactor macaroon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -652,6 +652,7 @@ frontend/static/assets/avatars*
 api/lightning/lightning*
 api/lightning/invoices*
 api/lightning/router*
+api/lightning/verrpc*
 api/lightning/googleapis*
 frontend/static/locales/collected_phrases.json
 frontend/static/admin*

--- a/api/management/commands/follow_invoices.py
+++ b/api/management/commands/follow_invoices.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
         """Follows and updates LNpayment objects
         until settled or canceled
 
-        Background: SubscribeInvoices stub iterator would be great to use here.
+        LND Background: SubscribeInvoices stub iterator would be great to use here.
         However, it only sends updates when the invoice is OPEN (new) or SETTLED.
         We are very interested on the other two states (CANCELLED and ACCEPTED).
         Therefore, this thread (follow_invoices) will iterate over all LNpayment

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -78,13 +78,11 @@ def give_rewards():
 def follow_send_payment(hash):
     """Sends sats to buyer, continuous update"""
 
-    from datetime import timedelta
-
     from decouple import config
     from django.utils import timezone
 
-    from api.lightning.node import MACAROON, LNNode
-    from api.models import LNPayment, Order
+    from api.lightning.node import LNNode
+    from api.models import LNPayment
 
     lnpayment = LNPayment.objects.get(payment_hash=hash)
     lnpayment.last_routing_time = timezone.now()
@@ -94,131 +92,10 @@ def follow_send_payment(hash):
     fee_limit_sat = int(
         float(lnpayment.num_satoshis) * float(lnpayment.routing_budget_ppm) / 1000000
     )
-    timeout_seconds = int(config("PAYOUT_TIMEOUT_SECONDS"))
+    timeout_seconds = config("PAYOUT_TIMEOUT_SECONDS", cast=int, default=90)
 
-    request = LNNode.routerrpc.SendPaymentRequest(
-        payment_request=lnpayment.invoice,
-        fee_limit_sat=fee_limit_sat,
-        timeout_seconds=timeout_seconds,
-        allow_self_payment=True,
-    )
-
-    order = lnpayment.order_paid_LN
-    if order.trade_escrow.num_satoshis < lnpayment.num_satoshis:
-        print(f"Order: {order.id} Payout is larger than collateral !?")
-        return
-
-    def handle_response(response, was_in_transit=False):
-        lnpayment.status = LNPayment.Status.FLIGHT
-        lnpayment.in_flight = True
-        lnpayment.save()
-        order.status = Order.Status.PAY
-        order.save()
-
-        if response.status == 0:  # Status 0 'UNKNOWN'
-            # Not sure when this status happens
-            print(f"Order: {order.id} UNKNOWN. Hash {hash}")
-            lnpayment.in_flight = False
-            lnpayment.save()
-
-        if response.status == 1:  # Status 1 'IN_FLIGHT'
-            print(f"Order: {order.id} IN_FLIGHT. Hash {hash}")
-
-            # If payment was already "payment is in transition" we do not
-            # want to spawn a new thread every 3 minutes to check on it.
-            # in case this thread dies, let's move the last_routing_time
-            # 20 minutes in the future so another thread spawns.
-            if was_in_transit:
-                lnpayment.last_routing_time = timezone.now() + timedelta(minutes=20)
-                lnpayment.save()
-
-        if response.status == 3:  # Status 3 'FAILED'
-            lnpayment.status = LNPayment.Status.FAILRO
-            lnpayment.last_routing_time = timezone.now()
-            lnpayment.routing_attempts += 1
-            lnpayment.failure_reason = response.failure_reason
-            lnpayment.in_flight = False
-            if lnpayment.routing_attempts > 2:
-                lnpayment.status = LNPayment.Status.EXPIRE
-                lnpayment.routing_attempts = 0
-            lnpayment.save()
-
-            order.status = Order.Status.FAI
-            order.expires_at = timezone.now() + timedelta(
-                seconds=order.t_to_expire(Order.Status.FAI)
-            )
-            order.save()
-            print(
-                f"Order: {order.id} FAILED. Hash: {hash} Reason: {LNNode.payment_failure_context[response.failure_reason]}"
-            )
-            return {
-                "succeded": False,
-                "context": f"payment failure reason: {LNNode.payment_failure_context[response.failure_reason]}",
-            }
-
-        if response.status == 2:  # Status 2 'SUCCEEDED'
-            print(f"Order: {order.id} SUCCEEDED. Hash: {hash}")
-            lnpayment.status = LNPayment.Status.SUCCED
-            lnpayment.fee = float(response.fee_msat) / 1000
-            lnpayment.preimage = response.payment_preimage
-            lnpayment.save()
-            order.status = Order.Status.SUC
-            order.expires_at = timezone.now() + timedelta(
-                seconds=order.t_to_expire(Order.Status.SUC)
-            )
-            order.save()
-            results = {"succeded": True}
-            return results
-
-    try:
-        for response in LNNode.routerstub.SendPaymentV2(
-            request, metadata=[("macaroon", MACAROON.hex())]
-        ):
-
-            handle_response(response)
-
-    except Exception as e:
-
-        if "invoice expired" in str(e):
-            print(f"Order: {order.id}. INVOICE EXPIRED. Hash: {hash}")
-            lnpayment.status = LNPayment.Status.EXPIRE
-            lnpayment.last_routing_time = timezone.now()
-            lnpayment.in_flight = False
-            lnpayment.save()
-            order.status = Order.Status.FAI
-            order.expires_at = timezone.now() + timedelta(
-                seconds=order.t_to_expire(Order.Status.FAI)
-            )
-            order.save()
-            results = {"succeded": False, "context": "The payout invoice has expired"}
-            return results
-
-        elif "payment is in transition" in str(e):
-            print(f"Order: {order.id} ALREADY IN TRANSITION. Hash: {hash}.")
-
-            request = LNNode.routerrpc.TrackPaymentRequest(
-                payment_hash=bytes.fromhex(hash)
-            )
-
-            for response in LNNode.routerstub.TrackPaymentV2(
-                request, metadata=[("macaroon", MACAROON.hex())]
-            ):
-                handle_response(response, was_in_transit=True)
-
-        elif "invoice is already paid" in str(e):
-            print(f"Order: {order.id} ALREADY PAID. Hash: {hash}.")
-
-            request = LNNode.routerrpc.TrackPaymentRequest(
-                payment_hash=bytes.fromhex(hash)
-            )
-
-            for response in LNNode.routerstub.TrackPaymentV2(
-                request, metadata=[("macaroon", MACAROON.hex())]
-            ):
-                handle_response(response)
-
-        else:
-            print(str(e))
+    results = LNNode.follow_send_payment(lnpayment, fee_limit_sat, timeout_seconds)
+    return results
 
 
 @shared_task(name="payments_cleansing", time_limit=600)

--- a/api/utils.py
+++ b/api/utils.py
@@ -118,23 +118,16 @@ def get_exchange_rates(currencies):
     return median_rates.tolist()
 
 
+lnd_version_cache = {}
+
+
+@ring.dict(lnd_version_cache, expire=3600)
 def get_lnd_version():
 
-    # If dockerized, return LND_VERSION envvar used for docker image.
-    # Otherwise it would require LND's version.grpc libraries...
-    try:
-        lnd_version = config("LND_VERSION")
-        return lnd_version
-    except Exception:
-        pass
+    from api.lightning.node import LNNode
 
-    # If not dockerized and LND is local, read from CLI
-    try:
-        stream = os.popen("lnd --version")
-        lnd_version = stream.read()[:-1]
-        return lnd_version
-    except Exception:
-        return ""
+    print(LNNode.get_version())
+    return LNNode.get_version()
 
 
 robosats_commit_cache = {}
@@ -163,7 +156,6 @@ def get_robosats_version():
     with open("version.json") as f:
         version_dict = json.load(f)
 
-    print(version_dict)
     return version_dict
 
 
@@ -177,7 +169,6 @@ def compute_premium_percentile(order):
         currency=order.currency, status=Order.Status.PUB, type=order.type
     ).exclude(id=order.id)
 
-    print(len(queryset))
     if len(queryset) <= 1:
         return 0.5
 

--- a/generate_grpc.sh
+++ b/generate_grpc.sh
@@ -3,16 +3,28 @@
 # generate grpc definitions
 cd api/lightning
 [ -d googleapis ] || git clone https://github.com/googleapis/googleapis.git googleapis
+
+# LND Lightning proto
 curl -o lightning.proto -s https://raw.githubusercontent.com/lightningnetwork/lnd/master/lnrpc/lightning.proto
 python3 -m grpc_tools.protoc --proto_path=googleapis:. --python_out=. --grpc_python_out=. lightning.proto
+
+# LND Invoices proto
 curl -o invoices.proto -s https://raw.githubusercontent.com/lightningnetwork/lnd/master/lnrpc/invoicesrpc/invoices.proto
 python3 -m grpc_tools.protoc --proto_path=googleapis:. --python_out=. --grpc_python_out=. invoices.proto
+
+# LND Router proto
 curl -o router.proto -s https://raw.githubusercontent.com/lightningnetwork/lnd/master/lnrpc/routerrpc/router.proto
 python3 -m grpc_tools.protoc --proto_path=googleapis:. --python_out=. --grpc_python_out=. router.proto
+
+# LND Versioner proto
+curl -o verrpc.proto -s https://raw.githubusercontent.com/lightningnetwork/lnd/master/lnrpc/verrpc/verrpc.proto
+python3 -m grpc_tools.protoc --proto_path=googleapis:. --python_out=. --grpc_python_out=. verrpc.proto
 
 # patch generated files relative imports
 sed -i 's/^import .*_pb2 as/from . \0/' router_pb2.py
 sed -i 's/^import .*_pb2 as/from . \0/' invoices_pb2.py
+sed -i 's/^import .*_pb2 as/from . \0/' verrpc_pb2.py
 sed -i 's/^import .*_pb2 as/from . \0/' router_pb2_grpc.py
 sed -i 's/^import .*_pb2 as/from . \0/' lightning_pb2_grpc.py
 sed -i 's/^import .*_pb2 as/from . \0/' invoices_pb2_grpc.py
+sed -i 's/^import .*_pb2 as/from . \0/' verrpc_pb2_grpc.py


### PR DESCRIPTION
## What does this PR do?
This PR refactors the use of LNNode. All gRPC calls to LND must take place in `api.lightning.node.py`. This PR also adds the Versioner RPC proto, so the LND version can be fetched via gRPC calls. 

## Checklist before merging
- [ ] If it's a frontend feature, I have ran prettier `cd frontend; npm run format`. If it's a mobile app feature I ran `cd mobile; npm run format`.
- [ ] If I added new phrases to the user interface, I have ran prettier `cd frontend/static/locales; python collect_phrases.py` to collect them for translation.