### PR TITLE
Add automatic dispute resolution

### DIFF
--- a/api/logics.py
+++ b/api/logics.py
@@ -431,15 +431,22 @@ class Logics:
 
     @classmethod
     def automatic_dispute_resolution(cls, order):
-        """Simple case where a dispute can be solved with a priori knowledge.
-        For example, a dispute that opens at expiration on an order where one of the participants never sent a message on the chat
-        and never marked 'fiat sent' . By solving the dispute automatically before flagging it as dispute, we avoid having to settle the bonds"""
+        """Simple case where a dispute can be solved with a
+        priori knowledge. For example, a dispute that opens
+        at expiration on an order where one of the participants
+        never sent a message on the chat and never marked 'fiat
+        sent'. By solving the dispute automatically before
+        flagging it as dispute, we avoid having to settle the
+        bonds"""
 
-        # If fiat has been marked as sent, automatic dispute resolution is not possible.
+        # If fiat has been marked as sent, automatic dispute
+        # resolution is not possible.
         if order.is_fiat_sent:
             return False
 
-        # If the order has not entered dispute due to time expire (a user triggered it), automatic dispute resolution is not possible.
+        # If the order has not entered dispute due to time expire
+        # (a user triggered it), automatic dispute resolution is
+        # not possible.
         if order.expires_at >= timezone.now():
             return False
 
@@ -451,22 +458,22 @@ class Logics:
         )
 
         if num_messages_maker == num_messages_taker == 0:
-            cls.cancel_escrow(order)
+            cls.return_escrow(order)
             cls.settle_bond(order.maker_bond)
             cls.settle_bond(order.taker_bond)
             order.status = Order.Status.DIS
 
         elif num_messages_maker == 0:
-            cls.cancel_escrow(order)
+            cls.return_escrow(order)
             cls.settle_bond(order.maker_bond)
-            cls.cancel_bond(order.taker_bond)
+            cls.return_bond(order.taker_bond)
             cls.add_slashed_rewards(order.maker_bond, order.taker.profile)
             order.status = Order.Status.MLD
 
         elif num_messages_maker == 0:
-            cls.cancel_escrow(order)
+            cls.return_escrow(order)
             cls.settle_bond(order.maker_bond)
-            cls.cancel_bond(order.taker_bond)
+            cls.return_bond(order.taker_bond)
             cls.add_slashed_rewards(order.taker_bond, order.maker.profile)
             order.status = Order.Status.TLD
         else:
@@ -539,9 +546,9 @@ class Logics:
                 "bad_request": "Only orders in dispute accept dispute statements"
             }
 
-        if len(statement) > 10000:
+        if len(statement) > 50000:
             return False, {
-                "bad_statement": "The statement is longer than 10000 characters"
+                "bad_statement": "The statement and chatlogs are longer than 50000 characters"
             }
 
         if len(statement) < 100:

--- a/api/models.py
+++ b/api/models.py
@@ -444,10 +444,10 @@ class Order(models.Model):
     # in dispute
     is_disputed = models.BooleanField(default=False, null=False)
     maker_statement = models.TextField(
-        max_length=10000, null=True, default=None, blank=True
+        max_length=50000, null=True, default=None, blank=True
     )
     taker_statement = models.TextField(
-        max_length=10000, null=True, default=None, blank=True
+        max_length=50000, null=True, default=None, blank=True
     )
 
     # LNpayments

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -492,7 +492,7 @@ class UpdateOrderSerializer(serializers.Serializer):
     routing_budget_ppm = serializers.IntegerField(
         default=0,
         min_value=0,
-        max_value=100000,
+        max_value=100001,
         allow_null=True,
         required=False,
         help_text="Max budget to allocate for routing in PPM",
@@ -501,7 +501,7 @@ class UpdateOrderSerializer(serializers.Serializer):
         max_length=100, allow_null=True, allow_blank=True, default=None
     )
     statement = serializers.CharField(
-        max_length=11000, allow_null=True, allow_blank=True, default=None
+        max_length=500000, allow_null=True, allow_blank=True, default=None
     )
     action = serializers.ChoiceField(
         choices=(


### PR DESCRIPTION
## What does this PR do?
This PR introduces a new `Logics` function to automatically resolve disputes before settling bonds for those cases where the exchange had obviously been impossible (3 conditions: no chat messages, fiat not marked as sent and dispute opened automatically at time expiry)

## Checklist before merging
- [ ] If it's a frontend feature, I have ran prettier `cd frontend; npm run format`. If it's a mobile app feature I ran `cd mobile; npm run format`.
- [ ] If I added new phrases to the user interface, I have ran prettier `cd frontend/static/locales; python collect_phrases.py` to collect them for translation.