### PR TITLE
Use premium to filter matches

### DIFF
--- a/frontend/src/basic/MakerPage/index.tsx
+++ b/frontend/src/basic/MakerPage/index.tsx
@@ -40,6 +40,7 @@ const MakerPage = (): JSX.Element => {
         type: fav.type,
         mode: fav.mode,
       },
+      premium: Number(maker.premium) ?? null,
       paymentMethods: maker.paymentMethods,
       amountFilter: {
         amount: maker.amount,
@@ -48,7 +49,7 @@ const MakerPage = (): JSX.Element => {
         threshold: 0.7,
       },
     });
-  }, [book.orders, fav, maker.amount, maker.minAmount, maker.maxAmount]);
+  }, [book.orders, fav, maker.premium, maker.amount, maker.minAmount, maker.maxAmount]);
 
   const onViewOrder = function () {
     setOrder(undefined);

--- a/frontend/src/utils/filterOrders.ts
+++ b/frontend/src/utils/filterOrders.ts
@@ -10,6 +10,7 @@ interface AmountFilter {
 interface FilterOrders {
   orders: PublicOrder[];
   baseFilter: Favorites;
+  premium: number | null;
   amountFilter?: AmountFilter | null;
   paymentMethods?: string[];
 }
@@ -42,20 +43,37 @@ const filterByAmount = function (order: PublicOrder, filter: AmountFilter) {
   return Math.max(filterMinAmount, orderMinAmount) <= Math.min(filterMaxAmount, orderMaxAmount);
 };
 
+const filterByPremium = function (order: PublicOrder, premium: number) {
+  if (order.type == 0) {
+    return order.premium >= premium;
+  } else {
+    return order.premium <= premium;
+  }
+};
+
 const filterOrders = function ({
   orders,
   baseFilter,
+  premium = null,
   paymentMethods = [],
   amountFilter = null,
 }: FilterOrders) {
   const filteredOrders = orders.filter((order) => {
     const typeChecks = order.type == baseFilter.type || baseFilter.type == null;
     const modeChecks = baseFilter.mode === 'fiat' ? !(order.currency === 1000) : true;
+    const premiumChecks = premium != null ? filterByPremium(order, premium) : true;
     const currencyChecks = order.currency == baseFilter.currency || baseFilter.currency == 0;
     const paymentMethodChecks =
       paymentMethods.length > 0 ? filterByPayment(order, paymentMethods) : true;
     const amountChecks = amountFilter != null ? filterByAmount(order, amountFilter) : true;
-    return typeChecks && modeChecks && currencyChecks && paymentMethodChecks && amountChecks;
+    return (
+      typeChecks &&
+      modeChecks &&
+      premiumChecks &&
+      currencyChecks &&
+      paymentMethodChecks &&
+      amountChecks
+    );
   });
   return filteredOrders;
 };


### PR DESCRIPTION
## What does this PR do?
Maker form premium is now used as a filter to show existing matching orders. Only those that have a strictly "better" premiums are shown (so lower premiums if buying, higher if selling).

## Checklist before merging
- [x] If it's a frontend feature, I have ran prettier `cd frontend; npm run format`. If it's a mobile app feature I ran `cd mobile; npm run format`.
- [ ] If I added new phrases to the user interface, I have ran prettier `cd frontend/static/locales; python collect_phrases.py` to collect them for translation.