### PR TITLE
Optimize follow-invoices service performance

### DIFF
--- a/api/lightning/node.py
+++ b/api/lightning/node.py
@@ -288,8 +288,6 @@ class LNNode:
                     pass
 
             status = lnd_response_state_to_lnpayment_status[response.state]
-            lnpayment.status = status
-            lnpayment.save()
 
         except Exception as e:
             # If it fails at finding the invoice: it has been canceled.
@@ -297,8 +295,6 @@ class LNNode:
             if "unable to locate invoice" in str(e):
                 print(str(e))
                 status = LNPayment.Status.CANCEL
-                lnpayment.status = status
-                lnpayment.save()
 
             # LND restarted.
             if "wallet locked, unlock it" in str(e):

--- a/api/management/commands/follow_invoices.py
+++ b/api/management/commands/follow_invoices.py
@@ -59,16 +59,16 @@ class Command(BaseCommand):
         at_least_one_changed = False
 
         for idx, hold_lnpayment in enumerate(queryset):
-            old_status = LNPayment.Status(hold_lnpayment.status).label
+            old_status = hold_lnpayment.status
 
-            status = LNNode.lookup_invoice_status(hold_lnpayment)
-            new_status = LNPayment.Status(status).label
+            new_status = LNNode.lookup_invoice_status(hold_lnpayment)
 
             # Only save the hold_payments that change (otherwise this function does not scale)
             changed = not old_status == new_status
             if changed:
                 # self.handle_status_change(hold_lnpayment, old_status)
                 self.update_order_status(hold_lnpayment)
+                hold_lnpayment.status = new_status
                 hold_lnpayment.save()
 
                 # Report for debugging


### PR DESCRIPTION
## What does this PR do?
Recent refactoring of LNNode introduced the `lookup_follow_invoice()` method. This one was saving every invoices state to DB even if it had not changed (something that early on during development was known to be inneficient, so the follow-invoices thread takes too long on each loop). This PR fixes it (once again).