### PR TITLE
Add slashed return on uneven stake slashed bonds

### DIFF
--- a/frontend/src/components/MakerForm/MakerForm.tsx
+++ b/frontend/src/components/MakerForm/MakerForm.tsx
@@ -75,7 +75,7 @@ const MakerForm = ({
   const [openDialogs, setOpenDialogs] = useState<boolean>(false);
   const [submittingRequest, setSubmittingRequest] = useState<boolean>(false);
 
-  const maxRangeAmountMultiple = 7.8;
+  const maxRangeAmountMultiple = 14.8;
   const minRangeAmountMultiple = 1.6;
   const amountSafeThresholds = [1.03, 0.98];
 


### PR DESCRIPTION
## What does this PR do?
This PR introduces a better handling for slashed bonds where the stakes were uneven. 

It may happen that the Sats at stake by the maker are larger than the Sats at stake by the taker. This is due to the fact that, in orders with a range amount, the maker stakes the upper size bond. However, a taker can decide to take an order of a smaller size. As such, the maker staked a bond larger than the taker.

With this PR, on those cases, the change between the slashed amount and the staked amount is added back to the robot that was slashed.

Thanks to this PR now range amounts are safer and we can increase the range maximum size limits. This PR increases the maximum possible range size from `x8` to `x15`.

## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.
- [ ] If I added new phrases to the user interface, I have ran prettier `cd frontend/static/locales; python collect_phrases.py` to collect them for translation.